### PR TITLE
feat(export): add multi-format export for logs and traces

### DIFF
--- a/web/app/components/shell/AppToolbar.vue
+++ b/web/app/components/shell/AppToolbar.vue
@@ -80,6 +80,37 @@ const { t } = useI18n()
             :is-live="a.isLive.value"
             @toggle="a.onToggle"
           />
+          <!-- Split button: primary on the left, caret on the right. The
+               two buttons share borders (negative margin + rounded sides)
+               so they read as one control. UDropdownMenu handles keyboard
+               nav and focus return. -->
+          <div v-else-if="a.kind === 'split'" class="inline-flex isolate">
+            <UButton
+              size="sm"
+              :color="a.color ?? 'neutral'"
+              :variant="a.variant ?? 'subtle'"
+              :icon="a.icon"
+              :loading="a.loading?.value"
+              :disabled="a.disabled?.value"
+              class="rounded-r-none transition-colors"
+              @click="a.onClick"
+            >
+              {{ t(a.labelKey) }}
+            </UButton>
+            <UDropdownMenu
+              :items="[a.items.map(it => ({ label: t(it.labelKey), icon: it.icon, onSelect: it.onClick }))]"
+            >
+              <UButton
+                size="sm"
+                :color="a.color ?? 'neutral'"
+                :variant="a.variant ?? 'subtle'"
+                icon="i-ph-caret-down"
+                :disabled="a.disabled?.value || a.loading?.value"
+                class="rounded-l-none border-l border-default/40 -ml-px"
+                :aria-label="t('common.moreOptions')"
+              />
+            </UDropdownMenu>
+          </div>
           <UButton
             v-else
             size="sm"

--- a/web/app/lib/otlpExport.ts
+++ b/web/app/lib/otlpExport.ts
@@ -1,0 +1,381 @@
+// OTLP/JSON export.
+//
+// Serialises in-memory logs / spans into the wire shape defined by
+// `opentelemetry-proto` (ExportLogsServiceRequest, ExportTraceServiceRequest):
+// the same envelope the OTel SDKs send and that downstream tools — the OTel
+// collector's `fileexporter`/`fileexporter` consumer, Jaeger's "JSON File"
+// loader, Tempo, Loki — round-trip without conversion.
+//
+// What the dashboard's DTOs *don't* carry round-trips imperfectly:
+// per-span resource attributes (we only have `service.name`), and resource
+// attributes on traces beyond the service name. We surface `resourceHash`
+// under the conventional-ish `dashboard.resource_hash` key on log records so
+// the export still groups identically when re-ingested by this tool.
+
+import type { LogRecordDto, SpanDto, SpanEventDto, SpanLinkDto } from '~/services/types'
+
+// --- OTLP wire shapes ----------------------------------------------------
+//
+// Typed against the proto3 JSON mapping. The int64 fields (`timeUnixNano`,
+// `intValue`) come out as strings because JSON numbers lose precision past
+// 2^53 — that's what every conformant OTLP/JSON reader expects.
+
+interface OtlpAnyValue {
+  stringValue?: string
+  boolValue?: boolean
+  intValue?: string
+  doubleValue?: number
+  arrayValue?: { values: OtlpAnyValue[] }
+  kvlistValue?: { values: OtlpKeyValue[] }
+}
+
+interface OtlpKeyValue {
+  key: string
+  value: OtlpAnyValue
+}
+
+interface OtlpResource {
+  attributes: OtlpKeyValue[]
+}
+
+interface OtlpInstrumentationScope {
+  name: string
+  version?: string
+}
+
+interface OtlpLogRecord {
+  timeUnixNano: string
+  observedTimeUnixNano?: string
+  severityNumber?: number
+  severityText?: string
+  body?: OtlpAnyValue
+  attributes: OtlpKeyValue[]
+  traceId?: string
+  spanId?: string
+}
+
+interface OtlpScopeLogs {
+  scope: OtlpInstrumentationScope
+  logRecords: OtlpLogRecord[]
+}
+
+interface OtlpResourceLogs {
+  resource: OtlpResource
+  scopeLogs: OtlpScopeLogs[]
+}
+
+interface OtlpSpanEvent {
+  timeUnixNano: string
+  name: string
+  attributes: OtlpKeyValue[]
+}
+
+interface OtlpSpanLink {
+  traceId: string
+  spanId: string
+  attributes: OtlpKeyValue[]
+}
+
+interface OtlpSpan {
+  traceId: string
+  spanId: string
+  parentSpanId?: string
+  name: string
+  kind: string
+  startTimeUnixNano: string
+  endTimeUnixNano: string
+  attributes: OtlpKeyValue[]
+  events: OtlpSpanEvent[]
+  links: OtlpSpanLink[]
+  status: { code: string; message?: string }
+}
+
+interface OtlpScopeSpans {
+  scope: OtlpInstrumentationScope
+  spans: OtlpSpan[]
+}
+
+interface OtlpResourceSpans {
+  resource: OtlpResource
+  scopeSpans: OtlpScopeSpans[]
+}
+
+export interface OtlpLogsExport {
+  resourceLogs: OtlpResourceLogs[]
+}
+
+export interface OtlpTracesExport {
+  resourceSpans: OtlpResourceSpans[]
+}
+
+// --- Builders ------------------------------------------------------------
+
+/**
+ * Group a flat list of log records into OTLP `resourceLogs`. Bucketing is by
+ * (resourceHash, serviceName) at the resource level and (scopeName,
+ * scopeVersion) at the scope level — mirrors how the records were originally
+ * grouped on the ingestion side, so re-ingesting the export reproduces the
+ * same resource fingerprint.
+ */
+export function buildLogsExport(logs: LogRecordDto[]): OtlpLogsExport {
+  // Two-level map keyed by stable, deterministic string keys. Using strings
+  // (rather than nested Maps of objects) keeps the grouping order stable
+  // across runs of the same input, which matters for snapshot tests.
+  const resources = new Map<string, {
+    resource: OtlpResource
+    scopes: Map<string, OtlpScopeLogs>
+  }>()
+
+  for (const log of logs) {
+    const resourceKey = `${log.resourceHash}|${log.serviceName ?? ''}`
+    let bucket = resources.get(resourceKey)
+    if (!bucket) {
+      bucket = {
+        resource: makeResource(log.serviceName, log.resourceHash),
+        scopes: new Map()
+      }
+      resources.set(resourceKey, bucket)
+    }
+    const scopeKey = `${log.scopeName ?? ''}|${log.scopeVersion ?? ''}`
+    let scope = bucket.scopes.get(scopeKey)
+    if (!scope) {
+      scope = {
+        scope: { name: log.scopeName ?? '', version: log.scopeVersion ?? undefined },
+        logRecords: []
+      }
+      bucket.scopes.set(scopeKey, scope)
+    }
+    scope.logRecords.push(toLogRecord(log))
+  }
+
+  return {
+    resourceLogs: Array.from(resources.values(), b => ({
+      resource: b.resource,
+      scopeLogs: Array.from(b.scopes.values())
+    }))
+  }
+}
+
+/** Input to {@link buildSpansExport}: one trace's spans, tagged with the
+ *  trace id they belong to so each emitted span carries the right
+ *  `traceId` field (it lives on the span in OTLP, not above it). */
+export interface TraceSpans {
+  traceId: string
+  spans: SpanDto[]
+}
+
+/**
+ * Group spans from one or more traces into OTLP `resourceSpans`. The DTO
+ * doesn't carry per-span resource attributes beyond `service.name`, so
+ * resources collapse by service. Spans without `serviceName` land under an
+ * empty-resource bucket — still valid OTLP, just unnamed.
+ */
+export function buildSpansExport(traces: TraceSpans[]): OtlpTracesExport {
+  const resources = new Map<string, {
+    resource: OtlpResource
+    scopes: Map<string, OtlpScopeSpans>
+  }>()
+
+  for (const trace of traces) {
+    for (const span of trace.spans) {
+      const resourceKey = span.serviceName ?? ''
+      let bucket = resources.get(resourceKey)
+      if (!bucket) {
+        bucket = {
+          resource: makeResource(span.serviceName, null),
+          scopes: new Map()
+        }
+        resources.set(resourceKey, bucket)
+      }
+      const scopeKey = `${span.scopeName ?? ''}|${span.scopeVersion ?? ''}`
+      let scope = bucket.scopes.get(scopeKey)
+      if (!scope) {
+        scope = {
+          scope: { name: span.scopeName ?? '', version: span.scopeVersion ?? undefined },
+          spans: []
+        }
+        bucket.scopes.set(scopeKey, scope)
+      }
+      scope.spans.push(toSpan(trace.traceId, span))
+    }
+  }
+
+  return {
+    resourceSpans: Array.from(resources.values(), b => ({
+      resource: b.resource,
+      scopeSpans: Array.from(b.scopes.values())
+    }))
+  }
+}
+
+// --- Resource / attribute helpers ----------------------------------------
+
+function makeResource(serviceName: string | null, resourceHash: string | null): OtlpResource {
+  const attrs: OtlpKeyValue[] = []
+  if (serviceName) attrs.push({ key: 'service.name', value: { stringValue: serviceName } })
+  // `resourceHash` is dashboard-internal — the canonical fingerprint our
+  // ingestion side derives from the source resource. Re-emitting it lets a
+  // re-import collapse onto the same resource row without depending on the
+  // full original attribute set.
+  if (resourceHash) attrs.push({ key: 'dashboard.resource_hash', value: { stringValue: resourceHash } })
+  return { attributes: attrs }
+}
+
+function toLogRecord(log: LogRecordDto): OtlpLogRecord {
+  const record: OtlpLogRecord = {
+    timeUnixNano: isoToUnixNano(log.time),
+    attributes: toKeyValueList(log.attributes)
+  }
+  if (log.observedTime) record.observedTimeUnixNano = isoToUnixNano(log.observedTime)
+  if (log.severityNumber > 0) record.severityNumber = log.severityNumber
+  if (log.severityText) record.severityText = log.severityText
+  if (log.body !== null && log.body !== undefined) record.body = { stringValue: log.body }
+  if (log.traceId) record.traceId = log.traceId
+  if (log.spanId) record.spanId = log.spanId
+  return record
+}
+
+function toSpan(traceId: string, span: SpanDto): OtlpSpan {
+  const out: OtlpSpan = {
+    traceId,
+    spanId: span.spanId,
+    name: span.name,
+    kind: mapSpanKind(span.kind),
+    startTimeUnixNano: isoToUnixNano(span.start),
+    endTimeUnixNano: isoToUnixNano(span.end),
+    attributes: toKeyValueList(span.attributes),
+    events: span.events.map(toSpanEvent),
+    links: span.links.map(toSpanLink),
+    status: mapStatus(span.statusCode, span.statusMessage)
+  }
+  if (span.parentSpanId) out.parentSpanId = span.parentSpanId
+  return out
+}
+
+function toSpanEvent(e: SpanEventDto): OtlpSpanEvent {
+  return {
+    timeUnixNano: isoToUnixNano(e.time),
+    name: e.name,
+    attributes: toKeyValueList(e.attributes)
+  }
+}
+
+function toSpanLink(l: SpanLinkDto): OtlpSpanLink {
+  return {
+    traceId: l.traceId,
+    spanId: l.spanId,
+    attributes: toKeyValueList(l.attributes)
+  }
+}
+
+function toKeyValueList(attrs: Record<string, unknown> | null | undefined): OtlpKeyValue[] {
+  if (!attrs) return []
+  const out: OtlpKeyValue[] = []
+  for (const [key, raw] of Object.entries(attrs)) {
+    const value = toAnyValue(raw)
+    if (value) out.push({ key, value })
+  }
+  return out
+}
+
+function toAnyValue(raw: unknown): OtlpAnyValue | null {
+  if (raw === null || raw === undefined) return null
+  if (typeof raw === 'string') return { stringValue: raw }
+  if (typeof raw === 'boolean') return { boolValue: raw }
+  if (typeof raw === 'number') {
+    // Integers within the safe range round-trip as `intValue` (string in
+    // proto3 JSON) so consumers don't see a float where the source was an
+    // int. Anything else — fractional, ±Inf, NaN, beyond 2^53 — goes as
+    // `doubleValue`. NaN/Inf can't be represented in strict JSON, so we
+    // bail to a string so the file stays parseable.
+    if (!Number.isFinite(raw)) return { stringValue: String(raw) }
+    if (Number.isInteger(raw) && Number.isSafeInteger(raw)) return { intValue: String(raw) }
+    return { doubleValue: raw }
+  }
+  if (typeof raw === 'bigint') return { intValue: raw.toString() }
+  if (Array.isArray(raw)) {
+    const values = raw.map(toAnyValue).filter((v): v is OtlpAnyValue => v !== null)
+    return { arrayValue: { values } }
+  }
+  if (typeof raw === 'object') {
+    return { kvlistValue: { values: toKeyValueList(raw as Record<string, unknown>) } }
+  }
+  return { stringValue: String(raw) }
+}
+
+// --- Enums ---------------------------------------------------------------
+
+function mapSpanKind(kind: string): string {
+  switch (kind) {
+    case 'Internal': return 'SPAN_KIND_INTERNAL'
+    case 'Server': return 'SPAN_KIND_SERVER'
+    case 'Client': return 'SPAN_KIND_CLIENT'
+    case 'Producer': return 'SPAN_KIND_PRODUCER'
+    case 'Consumer': return 'SPAN_KIND_CONSUMER'
+    default: return 'SPAN_KIND_UNSPECIFIED'
+  }
+}
+
+function mapStatus(code: string, message: string | null): OtlpSpan['status'] {
+  let mapped: string
+  switch (code) {
+    case 'Ok': mapped = 'STATUS_CODE_OK'; break
+    case 'Error': mapped = 'STATUS_CODE_ERROR'; break
+    default: mapped = 'STATUS_CODE_UNSET'
+  }
+  const status: OtlpSpan['status'] = { code: mapped }
+  if (message) status.message = message
+  return status
+}
+
+// --- Time conversion -----------------------------------------------------
+
+/**
+ * Convert an ISO-8601 timestamp to a nanoseconds-since-epoch string.
+ * JavaScript `Date` rounds to milliseconds, so we extract the fractional
+ * seconds separately and pad/truncate to 9 digits — keeps the sub-ms
+ * precision the .NET side serialises (DateTimeOffset has 100ns ticks).
+ */
+export function isoToUnixNano(iso: string): string {
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|[+-]\d{2}:?\d{2})?$/.exec(iso)
+  if (!match) {
+    const t = Date.parse(iso)
+    return Number.isNaN(t) ? '0' : (BigInt(t) * 1_000_000n).toString()
+  }
+  const [, head, frac, tz] = match
+  // `head` excludes the fractional component, so the parsed ms is
+  // second-aligned — we add the full fractional-nanosecond contribution
+  // below without any subtraction.
+  const ms = Date.parse(`${head}${tz ?? 'Z'}`)
+  if (Number.isNaN(ms)) return '0'
+  let nanos = BigInt(ms) * 1_000_000n
+  if (frac) {
+    // Drop the leading '.', pad to 9 digits, truncate to 9. Preserves
+    // .NET's 7-digit (100ns) precision exactly.
+    const digits = (frac.slice(1) + '000000000').slice(0, 9)
+    nanos += BigInt(digits)
+  }
+  return nanos.toString()
+}
+
+// --- File download -------------------------------------------------------
+
+/**
+ * Serialise `payload` and trigger a browser download. `.otlp.json` suffix
+ * signals the format to anyone scanning the downloads folder.
+ */
+export function downloadOtlpJson(payload: OtlpLogsExport | OtlpTracesExport, baseName: string): void {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${baseName}-${todayStamp()}.otlp.json`
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}
+
+function todayStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+}

--- a/web/app/lib/textExport.ts
+++ b/web/app/lib/textExport.ts
@@ -10,7 +10,7 @@
 // are intended as a *read* path (paste into an LLM, eyeball, grep), not as
 // a round-trippable wire format — for that, use the OTLP/JSON export.
 
-import type { LogRecordDto, SpanDto } from '~/services/types'
+import type { LogRecordDto, SpanDto, TraceSummaryDto } from '~/services/types'
 import type { TraceSpans } from './otlpExport'
 
 // --- logfmt --------------------------------------------------------------
@@ -166,6 +166,68 @@ function formatDuration(ms: number): string {
   if (ms < 1) return `${(ms * 1000).toFixed(0)}us`
   if (ms < 1000) return `${ms.toFixed(1)}ms`
   return `${(ms / 1000).toFixed(2)}s`
+}
+
+// --- CSV (RFC 4180) ------------------------------------------------------
+
+/**
+ * Render the logs grid as CSV. Columns mirror the on-screen table so the
+ * file matches "what I'm looking at": time, service, severity, scope,
+ * trace_id, span_id, body. Nested attribute structures are not surfaced —
+ * use the OTLP/JSON or logfmt export for those.
+ */
+export function buildLogsCsv(logs: LogRecordDto[]): string {
+  const header = ['time', 'service', 'severity', 'scope', 'trace_id', 'span_id', 'body']
+  const rows = logs.map(l => [
+    l.time,
+    l.serviceName ?? '',
+    l.severityText ?? (l.severityNumber > 0 ? String(l.severityNumber) : ''),
+    l.scopeName ?? '',
+    l.traceId ?? '',
+    l.spanId ?? '',
+    l.body ?? ''
+  ])
+  return formatCsv(header, rows)
+}
+
+/**
+ * Render the traces grid as CSV. Columns mirror the on-screen table:
+ * start, service, root_span, duration_ms, spans, status, trace_id. Per-span
+ * detail is intentionally omitted — for that, drill into a single trace and
+ * use the tree-text or OTLP export.
+ */
+export function buildTracesCsv(traces: TraceSummaryDto[]): string {
+  const header = ['start', 'service', 'root_span', 'duration_ms', 'spans', 'status', 'trace_id']
+  const rows = traces.map(t => [
+    t.start,
+    t.serviceName ?? '',
+    t.rootSpanName,
+    String(t.durationMs),
+    String(t.spanCount),
+    t.rootStatusCode,
+    t.traceId
+  ])
+  return formatCsv(header, rows)
+}
+
+function formatCsv(header: string[], rows: string[][]): string {
+  // LF line endings — modern spreadsheet tools (Excel since 2010, Numbers,
+  // Sheets) all accept them, and the file ends up ~50% smaller than CRLF
+  // on chatty log exports. The header row is always present so empty
+  // exports still produce a valid two-line file.
+  const lines = [header.map(csvField).join(',')]
+  for (const row of rows) lines.push(row.map(csvField).join(','))
+  return lines.join('\n') + '\n'
+}
+
+/** RFC 4180 field quoting: wrap when the value contains a comma, quote,
+ *  CR, or LF; double internal quotes. Bare value otherwise — keeps small
+ *  files visually compact. */
+function csvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
 }
 
 // --- file download -------------------------------------------------------

--- a/web/app/lib/textExport.ts
+++ b/web/app/lib/textExport.ts
@@ -17,9 +17,17 @@ import type { TraceSpans } from './otlpExport'
 
 /**
  * Render a flat list of log records as logfmt — one line per record. Field
- * order is fixed (time → level → service → scope → correlation → message →
- * attributes) so a grep-friendly column-ish layout falls out for free when
- * you align columns in a text viewer.
+ * order is fixed (time → level → service → scope → correlation → message)
+ * so a grep-friendly column-ish layout falls out for free when you align
+ * columns in a text viewer.
+ *
+ * Structured attributes are intentionally *not* emitted. The `msg` body is
+ * already the substituted form (e.g. "counter set to 894"), so the
+ * attribute map mostly carries either values that are already inside the
+ * message text (`Value=894`), the raw template (`{OriginalFormat}`), or
+ * enrichment that duplicates the top-level columns (`SpanId`, `TraceId`).
+ * Listing them inflates each line with noise. Callers who need the
+ * structured shape use the OTLP/JSON export, which round-trips verbatim.
  */
 export function buildLogfmt(logs: LogRecordDto[]): string {
   const lines: string[] = []
@@ -33,14 +41,6 @@ export function buildLogfmt(logs: LogRecordDto[]): string {
     if (log.traceId) parts.push(kv('trace_id', log.traceId))
     if (log.spanId) parts.push(kv('span_id', log.spanId))
     if (log.body !== null && log.body !== undefined) parts.push(kv('msg', log.body))
-    // Attributes are namespaced under `attr.` so they don't collide with
-    // the well-known top-level keys (`time`, `level`, etc.). Nested values
-    // are flattened to JSON-ish text — logfmt is a flat key=value protocol
-    // by design.
-    for (const [k, v] of Object.entries(log.attributes ?? {})) {
-      if (v === null || v === undefined) continue
-      parts.push(kv(`attr.${k}`, formatValue(v)))
-    }
     lines.push(parts.join(' '))
   }
   return lines.join('\n') + (lines.length > 0 ? '\n' : '')
@@ -228,6 +228,66 @@ function csvField(value: string): string {
     return `"${value.replace(/"/g, '""')}"`
   }
   return value
+}
+
+// --- clipboard / LLM-friendly markdown -----------------------------------
+//
+// The clipboard exports wrap one of the existing text formats inside a
+// short markdown envelope:
+//
+//   **OtlpDashboard <kind>**
+//   <context lines>
+//
+//   ```<lang>
+//   <body>
+//   ```
+//
+// The context block — window, active filters, count — is what makes the
+// paste useful in an LLM chat: it tells the model what it's looking at
+// without the user having to retype it. Pages assemble their own context
+// lines locally (they're the only ones that know the live filter state).
+
+/** Wrap a body payload in the markdown envelope above. `fenceLang` flags
+ *  the code block (`log` for logfmt, blank for the trace tree) — most
+ *  syntax highlighters ignore unknown tags, but `log` does have shading
+ *  in popular themes. */
+export function buildClipboardMarkdown(
+  title: string,
+  contextLines: string[],
+  body: string,
+  fenceLang = ''
+): string {
+  const sections = [`**${title}**`, ...contextLines, '', `\`\`\`${fenceLang}`, body.replace(/\n+$/, ''), '```']
+  return sections.join('\n') + '\n'
+}
+
+/**
+ * One-line-per-trace summary for the traces-list clipboard export. Compact
+ * on purpose — the alternative (a tree per trace) would either need N
+ * detail fetches or blow up the token budget. Fields mirror what the user
+ * scans in the table: `<id>  <root>  [<status> <duration> <spans>]  service=...`.
+ */
+export function buildTracesSummaryList(traces: TraceSummaryDto[]): string {
+  const lines = traces.map(t => {
+    const idShort = t.traceId.length > 16 ? `${t.traceId.slice(0, 16)}…` : t.traceId
+    const meta = `[${t.rootStatusCode.toLowerCase()} ${formatDuration(t.durationMs)} ${t.spanCount} spans]`
+    const tail = t.serviceName ? `  ${kv('service', t.serviceName)}` : ''
+    return `- ${idShort}  ${t.rootSpanName}  ${meta}${tail}`
+  })
+  return lines.join('\n') + (lines.length > 0 ? '\n' : '')
+}
+
+/** Write `text` to the system clipboard. Returns `true` on success, `false`
+ *  when the browser blocks the call (insecure context, missing permission,
+ *  etc.) — the caller decides how to surface the failure. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator === 'undefined' || !navigator.clipboard) return false
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
 }
 
 // --- file download -------------------------------------------------------

--- a/web/app/lib/textExport.ts
+++ b/web/app/lib/textExport.ts
@@ -1,0 +1,190 @@
+// Compact, human-readable export formats.
+//
+// Logs use `logfmt` (Heroku/Grafana/Loki convention): `key=value` pairs
+// separated by spaces, with values quoted only when ambiguous. Traces use
+// an indented ASCII tree — token-cheap for LLM consumption while staying
+// readable to a human scanning a terminal.
+//
+// Both formats are lossy with respect to OTLP: nested attribute structures
+// are flattened, some type nuances (int vs double) collapse to text. They
+// are intended as a *read* path (paste into an LLM, eyeball, grep), not as
+// a round-trippable wire format — for that, use the OTLP/JSON export.
+
+import type { LogRecordDto, SpanDto } from '~/services/types'
+import type { TraceSpans } from './otlpExport'
+
+// --- logfmt --------------------------------------------------------------
+
+/**
+ * Render a flat list of log records as logfmt — one line per record. Field
+ * order is fixed (time → level → service → scope → correlation → message →
+ * attributes) so a grep-friendly column-ish layout falls out for free when
+ * you align columns in a text viewer.
+ */
+export function buildLogfmt(logs: LogRecordDto[]): string {
+  const lines: string[] = []
+  for (const log of logs) {
+    const parts: string[] = []
+    parts.push(kv('time', log.time))
+    if (log.severityText) parts.push(kv('level', log.severityText))
+    else if (log.severityNumber > 0) parts.push(kv('level', String(log.severityNumber)))
+    if (log.serviceName) parts.push(kv('service', log.serviceName))
+    if (log.scopeName) parts.push(kv('scope', log.scopeName))
+    if (log.traceId) parts.push(kv('trace_id', log.traceId))
+    if (log.spanId) parts.push(kv('span_id', log.spanId))
+    if (log.body !== null && log.body !== undefined) parts.push(kv('msg', log.body))
+    // Attributes are namespaced under `attr.` so they don't collide with
+    // the well-known top-level keys (`time`, `level`, etc.). Nested values
+    // are flattened to JSON-ish text — logfmt is a flat key=value protocol
+    // by design.
+    for (const [k, v] of Object.entries(log.attributes ?? {})) {
+      if (v === null || v === undefined) continue
+      parts.push(kv(`attr.${k}`, formatValue(v)))
+    }
+    lines.push(parts.join(' '))
+  }
+  return lines.join('\n') + (lines.length > 0 ? '\n' : '')
+}
+
+function kv(key: string, value: string): string {
+  return `${key}=${quoteIfNeeded(value)}`
+}
+
+/**
+ * Quote per logfmt rules: bare when the value is non-empty and contains
+ * none of `space " = \\ \n \r`, quoted otherwise. Inside quotes, escape
+ * backslash and double-quote so the value round-trips through any
+ * standard logfmt parser.
+ */
+function quoteIfNeeded(value: string): string {
+  if (value === '') return '""'
+  if (/[\s"=\\]/.test(value)) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r')}"`
+  }
+  return value
+}
+
+function formatValue(v: unknown): string {
+  if (typeof v === 'string') return v
+  if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') return String(v)
+  // Objects / arrays don't have a sensible flat shape — fall back to JSON
+  // so the value is at least machine-parseable downstream.
+  try {
+    return JSON.stringify(v)
+  } catch {
+    return String(v)
+  }
+}
+
+// --- trace tree ----------------------------------------------------------
+
+/**
+ * Render a single trace as an indented ASCII tree. Pure ASCII (no
+ * box-drawing characters) — keeps the file LLM-friendly: each indent step
+ * is two spaces + `- `, which most tokenisers fold into a single token.
+ *
+ * Layout per line:
+ *   {indent}- {name}  [{kind} {status} {duration}]  service={svc}  attr.k=v ...
+ *
+ * Orphan spans (parent not in the slice) are emitted at depth 0 so nothing
+ * disappears from a truncated trace.
+ */
+export function buildTraceTree(trace: TraceSpans): string {
+  const lines: string[] = []
+  lines.push(traceHeader(trace))
+  if (trace.spans.length === 0) {
+    lines.push('  (no spans)')
+    return lines.join('\n') + '\n'
+  }
+
+  // Build child-index once: O(N) walk, then a depth-first emit.
+  const byParent = new Map<string | null, SpanDto[]>()
+  const ids = new Set<string>()
+  for (const s of trace.spans) ids.add(s.spanId)
+  for (const s of trace.spans) {
+    const parent = s.parentSpanId && ids.has(s.parentSpanId) ? s.parentSpanId : null
+    const bucket = byParent.get(parent) ?? []
+    bucket.push(s)
+    byParent.set(parent, bucket)
+  }
+  // Stable order by start time within each sibling group — gives a
+  // chronological flow that's easy to follow when scanning a deep tree.
+  for (const list of byParent.values()) {
+    list.sort((a, b) => a.start.localeCompare(b.start))
+  }
+
+  function emit(span: SpanDto, depth: number) {
+    lines.push(formatSpanLine(span, depth))
+    const children = byParent.get(span.spanId)
+    if (children) {
+      for (const c of children) emit(c, depth + 1)
+    }
+  }
+
+  for (const root of byParent.get(null) ?? []) emit(root, 0)
+  return lines.join('\n') + '\n'
+}
+
+/**
+ * Render a list of traces as a series of trees, separated by a blank line.
+ * Each tree carries its own one-line header (`trace=… duration=… spans=…`)
+ * so a slice of the output stays meaningful on its own.
+ */
+export function buildTraceTrees(traces: TraceSpans[]): string {
+  return traces.map(buildTraceTree).join('\n')
+}
+
+function traceHeader(trace: TraceSpans): string {
+  if (trace.spans.length === 0) {
+    return `trace=${trace.traceId} spans=0`
+  }
+  let minStart = trace.spans[0]!.start
+  let maxEnd = trace.spans[0]!.end
+  for (const s of trace.spans) {
+    if (s.start < minStart) minStart = s.start
+    if (s.end > maxEnd) maxEnd = s.end
+  }
+  const durationMs = new Date(maxEnd).getTime() - new Date(minStart).getTime()
+  return `trace=${trace.traceId} start=${minStart} duration=${formatDuration(durationMs)} spans=${trace.spans.length}`
+}
+
+function formatSpanLine(span: SpanDto, depth: number): string {
+  const indent = '  '.repeat(depth)
+  const meta = `[${span.kind.toLowerCase()} ${span.statusCode.toLowerCase()} ${formatDuration(span.durationMs)}]`
+  const tail: string[] = []
+  if (span.serviceName) tail.push(kv('service', span.serviceName))
+  if (span.statusMessage) tail.push(kv('error', span.statusMessage))
+  for (const [k, v] of Object.entries(span.attributes ?? {})) {
+    if (v === null || v === undefined) continue
+    tail.push(kv(`attr.${k}`, formatValue(v)))
+  }
+  return `${indent}- ${span.name}  ${meta}${tail.length > 0 ? '  ' + tail.join(' ') : ''}`
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '?'
+  if (ms < 1) return `${(ms * 1000).toFixed(0)}us`
+  if (ms < 1000) return `${ms.toFixed(1)}ms`
+  return `${(ms / 1000).toFixed(2)}s`
+}
+
+// --- file download -------------------------------------------------------
+
+/** Trigger a browser download for a text payload. Extension drives the
+ *  filename suffix; content-type stays `text/plain` so editors and the
+ *  browser preview both render it inline. */
+export function downloadText(content: string, baseName: string, extension: string): void {
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${baseName}-${todayStamp()}.${extension}`
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}
+
+function todayStamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+}

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -12,6 +12,7 @@ import LogsSeverityHistogram from './components/LogsSeverityHistogram.vue'
 import { useInMemoryLogsHistogram } from './composables/useSeverityHistogram'
 import { useLogsPage } from './usePage'
 import { buildLogsExport, downloadOtlpJson } from '~/lib/otlpExport'
+import { buildLogfmt, downloadText } from '~/lib/textExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -131,14 +132,26 @@ const filters: FilterDescriptor[] = [
 // paused; if rows arrive between the click and the file write they're
 // included.
 const exportDisabled = computed(() => page.items.value.length === 0)
-function exportLogs() {
+function exportLogsOtlp() {
   if (page.items.value.length === 0) return
-  const envelope = buildLogsExport(page.items.value)
-  downloadOtlpJson(envelope, 'logs')
+  downloadOtlpJson(buildLogsExport(page.items.value), 'logs')
+}
+function exportLogsLogfmt() {
+  if (page.items.value.length === 0) return
+  downloadText(buildLogfmt(page.items.value), 'logs', 'log')
 }
 
 const actions: ActionDescriptor[] = [
-  { kind: 'custom', labelKey: 'logs.exportOtlp', icon: 'i-ph-download-simple', onClick: exportLogs, disabled: exportDisabled },
+  {
+    kind: 'split',
+    labelKey: 'logs.export.otlp',
+    icon: 'i-ph-download-simple',
+    onClick: exportLogsOtlp,
+    disabled: exportDisabled,
+    items: [
+      { labelKey: 'logs.export.logfmt', icon: 'i-ph-text-aa', onClick: exportLogsLogfmt }
+    ]
+  },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },
   { kind: 'live', isLive: page.isLive, onToggle: page.toggleLive }
 ]

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -12,7 +12,13 @@ import LogsSeverityHistogram from './components/LogsSeverityHistogram.vue'
 import { useInMemoryLogsHistogram } from './composables/useSeverityHistogram'
 import { useLogsPage } from './usePage'
 import { buildLogsExport, downloadOtlpJson } from '~/lib/otlpExport'
-import { buildLogfmt, buildLogsCsv, downloadText } from '~/lib/textExport'
+import {
+  buildClipboardMarkdown,
+  buildLogfmt,
+  buildLogsCsv,
+  copyToClipboard,
+  downloadText
+} from '~/lib/textExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -145,6 +151,30 @@ function exportLogsCsv() {
   downloadText(buildLogsCsv(page.items.value), 'logs', 'csv')
 }
 
+const toast = useToast()
+async function copyLogsToClipboard() {
+  if (page.items.value.length === 0) return
+  const filters: string[] = []
+  if (page.service.value.length > 0) filters.push(`service=${page.service.value.join(',')}`)
+  if (page.severityFilter.value.length > 0) filters.push(`severity=${page.severityFilter.value.join(',')}`)
+  if (page.bodyQuery.value.trim()) filters.push(`body~="${page.bodyQuery.value.trim()}"`)
+  if (page.attributeFilters.value.length > 0) filters.push(`attr=${page.attributeFilters.value.join(',')}`)
+  if (page.traceId.value) filters.push(`trace_id=${page.traceId.value}`)
+  const context = [
+    `Window: ${page.range.value.from} → ${page.range.value.to}`,
+    `Filters: ${filters.length > 0 ? filters.join(' · ') : '(none)'}`,
+    `Count: ${page.items.value.length} records`
+  ]
+  // CSV body in the clipboard: schema declared once, rows are pure data —
+  // ~5× fewer tokens than logfmt for a typical page. The file-download
+  // `.log` (logfmt) variant still exists for grep-style filtering.
+  const md = buildClipboardMarkdown('OtlpDashboard logs', context, buildLogsCsv(page.items.value), 'csv')
+  const ok = await copyToClipboard(md)
+  toast.add(ok
+    ? { title: t('common.copied'), color: 'success', icon: 'i-ph-check' }
+    : { title: t('common.copyFailed'), color: 'error', icon: 'i-ph-x' })
+}
+
 const actions: ActionDescriptor[] = [
   {
     kind: 'split',
@@ -154,7 +184,8 @@ const actions: ActionDescriptor[] = [
     disabled: exportDisabled,
     items: [
       { labelKey: 'logs.export.logfmt', icon: 'i-ph-text-aa', onClick: exportLogsLogfmt },
-      { labelKey: 'logs.export.csv', icon: 'i-ph-file-csv', onClick: exportLogsCsv }
+      { labelKey: 'logs.export.csv', icon: 'i-ph-file-csv', onClick: exportLogsCsv },
+      { labelKey: 'logs.export.clipboard', icon: 'i-ph-clipboard-text', onClick: copyLogsToClipboard }
     ]
   },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -12,7 +12,7 @@ import LogsSeverityHistogram from './components/LogsSeverityHistogram.vue'
 import { useInMemoryLogsHistogram } from './composables/useSeverityHistogram'
 import { useLogsPage } from './usePage'
 import { buildLogsExport, downloadOtlpJson } from '~/lib/otlpExport'
-import { buildLogfmt, downloadText } from '~/lib/textExport'
+import { buildLogfmt, buildLogsCsv, downloadText } from '~/lib/textExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -140,6 +140,10 @@ function exportLogsLogfmt() {
   if (page.items.value.length === 0) return
   downloadText(buildLogfmt(page.items.value), 'logs', 'log')
 }
+function exportLogsCsv() {
+  if (page.items.value.length === 0) return
+  downloadText(buildLogsCsv(page.items.value), 'logs', 'csv')
+}
 
 const actions: ActionDescriptor[] = [
   {
@@ -149,7 +153,8 @@ const actions: ActionDescriptor[] = [
     onClick: exportLogsOtlp,
     disabled: exportDisabled,
     items: [
-      { labelKey: 'logs.export.logfmt', icon: 'i-ph-text-aa', onClick: exportLogsLogfmt }
+      { labelKey: 'logs.export.logfmt', icon: 'i-ph-text-aa', onClick: exportLogsLogfmt },
+      { labelKey: 'logs.export.csv', icon: 'i-ph-file-csv', onClick: exportLogsCsv }
     ]
   },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -11,6 +11,7 @@ import LogDetailContent from './components/LogDetailContent.vue'
 import LogsSeverityHistogram from './components/LogsSeverityHistogram.vue'
 import { useInMemoryLogsHistogram } from './composables/useSeverityHistogram'
 import { useLogsPage } from './usePage'
+import { buildLogsExport, downloadOtlpJson } from '~/lib/otlpExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -125,7 +126,19 @@ const filters: FilterDescriptor[] = [
   { kind: 'limit', modelValue: page.limit, disabled: page.isLive }
 ]
 
+// Export captures whatever is loaded right now — same "export what I'm
+// looking at" principle the metrics tree follows. The live tail isn't
+// paused; if rows arrive between the click and the file write they're
+// included.
+const exportDisabled = computed(() => page.items.value.length === 0)
+function exportLogs() {
+  if (page.items.value.length === 0) return
+  const envelope = buildLogsExport(page.items.value)
+  downloadOtlpJson(envelope, 'logs')
+}
+
 const actions: ActionDescriptor[] = [
+  { kind: 'custom', labelKey: 'logs.exportOtlp', icon: 'i-ph-download-simple', onClick: exportLogs, disabled: exportDisabled },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },
   { kind: 'live', isLive: page.isLive, onToggle: page.toggleLive }
 ]

--- a/web/app/pages/traces/[traceId].vue
+++ b/web/app/pages/traces/[traceId].vue
@@ -10,7 +10,12 @@ import SpanFlameGraph from './components/SpanFlameGraph.vue'
 import SpanDetailPanel from './components/SpanDetailPanel.vue'
 import { useTracePage } from './useTracePage'
 import { buildSpansExport, downloadOtlpJson } from '~/lib/otlpExport'
-import { buildTraceTree, downloadText } from '~/lib/textExport'
+import {
+  buildClipboardMarkdown,
+  buildTraceTree,
+  copyToClipboard,
+  downloadText
+} from '~/lib/textExport'
 import type { ActionDescriptor, BreadcrumbItem } from '~/types/toolbar'
 
 const { t, locale } = useI18n()
@@ -89,6 +94,26 @@ function exportTraceTree() {
   downloadText(text, `trace-${trace.traceId.slice(0, 12)}`, 'txt')
 }
 
+const toast = useToast()
+async function copyTraceToClipboard() {
+  const trace = page.trace.value
+  const s = summary.value
+  if (!trace || !s) return
+  const rootSpan = trace.spans.find(sp => !sp.parentSpanId) ?? trace.spans[0]
+  const context = [
+    `Trace: ${trace.traceId}`,
+    `Root: ${s.rootName}${rootSpan?.serviceName ? ` · Service: ${rootSpan.serviceName}` : ''}`,
+    `Duration: ${fmtDuration(s.durationMs)} · Spans: ${s.spanCount} · Status: ${rootSpan?.statusCode ?? '?'}`,
+    `Window: ${s.start} → ${s.end}`
+  ]
+  const body = buildTraceTree({ traceId: trace.traceId, spans: trace.spans })
+  const md = buildClipboardMarkdown('OtlpDashboard trace', context, body)
+  const ok = await copyToClipboard(md)
+  toast.add(ok
+    ? { title: t('common.copied'), color: 'success', icon: 'i-ph-check' }
+    : { title: t('common.copyFailed'), color: 'error', icon: 'i-ph-x' })
+}
+
 const actions = computed<ActionDescriptor[]>(() => {
   if (!summary.value || !page.trace.value) return []
   const s = summary.value
@@ -99,7 +124,8 @@ const actions = computed<ActionDescriptor[]>(() => {
       icon: 'i-ph-download-simple',
       onClick: exportTraceOtlp,
       items: [
-        { labelKey: 'traces.detail.export.tree', icon: 'i-ph-tree-view', onClick: exportTraceTree }
+        { labelKey: 'traces.detail.export.tree', icon: 'i-ph-tree-view', onClick: exportTraceTree },
+        { labelKey: 'traces.detail.export.clipboard', icon: 'i-ph-clipboard-text', onClick: copyTraceToClipboard }
       ]
     },
     {

--- a/web/app/pages/traces/[traceId].vue
+++ b/web/app/pages/traces/[traceId].vue
@@ -10,6 +10,7 @@ import SpanFlameGraph from './components/SpanFlameGraph.vue'
 import SpanDetailPanel from './components/SpanDetailPanel.vue'
 import { useTracePage } from './useTracePage'
 import { buildSpansExport, downloadOtlpJson } from '~/lib/otlpExport'
+import { buildTraceTree, downloadText } from '~/lib/textExport'
 import type { ActionDescriptor, BreadcrumbItem } from '~/types/toolbar'
 
 const { t, locale } = useI18n()
@@ -75,11 +76,17 @@ const subtitle = computed(() => {
   return `${fmtTime(s.start)} → ${fmtTime(s.end)} · ${fmtDuration(s.durationMs)} · ${t('traces.detail.spanCount', { count: s.spanCount })}`
 })
 
-function exportTrace() {
+function exportTraceOtlp() {
   const trace = page.trace.value
   if (!trace) return
   const envelope = buildSpansExport([{ traceId: trace.traceId, spans: trace.spans }])
   downloadOtlpJson(envelope, `trace-${trace.traceId.slice(0, 12)}`)
+}
+function exportTraceTree() {
+  const trace = page.trace.value
+  if (!trace) return
+  const text = buildTraceTree({ traceId: trace.traceId, spans: trace.spans })
+  downloadText(text, `trace-${trace.traceId.slice(0, 12)}`, 'txt')
 }
 
 const actions = computed<ActionDescriptor[]>(() => {
@@ -87,10 +94,13 @@ const actions = computed<ActionDescriptor[]>(() => {
   const s = summary.value
   return [
     {
-      kind: 'custom',
-      labelKey: 'traces.detail.exportOtlp',
+      kind: 'split',
+      labelKey: 'traces.detail.export.otlp',
       icon: 'i-ph-download-simple',
-      onClick: exportTrace
+      onClick: exportTraceOtlp,
+      items: [
+        { labelKey: 'traces.detail.export.tree', icon: 'i-ph-tree-view', onClick: exportTraceTree }
+      ]
     },
     {
       kind: 'custom',

--- a/web/app/pages/traces/[traceId].vue
+++ b/web/app/pages/traces/[traceId].vue
@@ -9,6 +9,7 @@ import SpanTree from './components/SpanTree.vue'
 import SpanFlameGraph from './components/SpanFlameGraph.vue'
 import SpanDetailPanel from './components/SpanDetailPanel.vue'
 import { useTracePage } from './useTracePage'
+import { buildSpansExport, downloadOtlpJson } from '~/lib/otlpExport'
 import type { ActionDescriptor, BreadcrumbItem } from '~/types/toolbar'
 
 const { t, locale } = useI18n()
@@ -74,22 +75,37 @@ const subtitle = computed(() => {
   return `${fmtTime(s.start)} → ${fmtTime(s.end)} · ${fmtDuration(s.durationMs)} · ${t('traces.detail.spanCount', { count: s.spanCount })}`
 })
 
+function exportTrace() {
+  const trace = page.trace.value
+  if (!trace) return
+  const envelope = buildSpansExport([{ traceId: trace.traceId, spans: trace.spans }])
+  downloadOtlpJson(envelope, `trace-${trace.traceId.slice(0, 12)}`)
+}
+
 const actions = computed<ActionDescriptor[]>(() => {
   if (!summary.value || !page.trace.value) return []
   const s = summary.value
-  return [{
-    kind: 'custom',
-    labelKey: 'traces.detail.viewLogs',
-    icon: 'i-ph-file-text',
-    onClick: () => navigateTo({
-      path: '/logs',
-      query: {
-        traceId: page.trace.value!.traceId,
-        from: new Date(new Date(s.start).getTime() - 60_000).toISOString(),
-        to: new Date(new Date(s.end).getTime() + 60_000).toISOString()
-      }
-    })
-  }]
+  return [
+    {
+      kind: 'custom',
+      labelKey: 'traces.detail.exportOtlp',
+      icon: 'i-ph-download-simple',
+      onClick: exportTrace
+    },
+    {
+      kind: 'custom',
+      labelKey: 'traces.detail.viewLogs',
+      icon: 'i-ph-file-text',
+      onClick: () => navigateTo({
+        path: '/logs',
+        query: {
+          traceId: page.trace.value!.traceId,
+          from: new Date(new Date(s.start).getTime() - 60_000).toISOString(),
+          to: new Date(new Date(s.end).getTime() + 60_000).toISOString()
+        }
+      })
+    }
+  ]
 })
 </script>
 

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -9,7 +9,14 @@ import TraceServiceCell from '~/components/data/cells/TraceServiceCell.vue'
 import DurationBarCell from '~/components/data/cells/DurationBarCell.vue'
 import { useTracesPage } from './usePage'
 import { buildSpansExport, downloadOtlpJson, type TraceSpans } from '~/lib/otlpExport'
-import { buildTraceTrees, buildTracesCsv, downloadText } from '~/lib/textExport'
+import {
+  buildClipboardMarkdown,
+  buildTraceTrees,
+  buildTracesCsv,
+  buildTracesSummaryList,
+  copyToClipboard,
+  downloadText
+} from '~/lib/textExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -167,6 +174,29 @@ function exportTracesCsv() {
   downloadText(buildTracesCsv(page.items.value), 'traces', 'csv')
 }
 
+const toast = useToast()
+async function copyTracesToClipboard() {
+  if (page.items.value.length === 0) return
+  const filters: string[] = []
+  if (page.service.value.length > 0) filters.push(`service=${page.service.value.join(',')}`)
+  if (page.statusFilter.value !== 'any') filters.push(`status=${page.statusFilter.value}`)
+  const d = page.durationFilter.value
+  if (d.minMs != null) filters.push(`duration_ms>=${d.minMs}`)
+  if (d.maxMs != null) filters.push(`duration_ms<=${d.maxMs}`)
+  if (page.searchQuery.value.trim()) filters.push(`span_name~="${page.searchQuery.value.trim()}"`)
+  if (page.attributeFilters.value.length > 0) filters.push(`attr=${page.attributeFilters.value.join(',')}`)
+  const context = [
+    `Window: ${page.range.value.from} → ${page.range.value.to}`,
+    `Filters: ${filters.length > 0 ? filters.join(' · ') : '(none)'}`,
+    `Count: ${page.items.value.length} traces`
+  ]
+  const md = buildClipboardMarkdown('OtlpDashboard traces', context, buildTracesSummaryList(page.items.value))
+  const ok = await copyToClipboard(md)
+  toast.add(ok
+    ? { title: t('common.copied'), color: 'success', icon: 'i-ph-check' }
+    : { title: t('common.copyFailed'), color: 'error', icon: 'i-ph-x' })
+}
+
 const actions: ActionDescriptor[] = [
   {
     kind: 'split',
@@ -177,7 +207,8 @@ const actions: ActionDescriptor[] = [
     disabled: exportDisabled,
     items: [
       { labelKey: 'traces.export.tree', icon: 'i-ph-tree-view', onClick: exportTracesTree },
-      { labelKey: 'traces.export.csv', icon: 'i-ph-file-csv', onClick: exportTracesCsv }
+      { labelKey: 'traces.export.csv', icon: 'i-ph-file-csv', onClick: exportTracesCsv },
+      { labelKey: 'traces.export.clipboard', icon: 'i-ph-clipboard-text', onClick: copyTracesToClipboard }
     ]
   },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -9,6 +9,7 @@ import TraceServiceCell from '~/components/data/cells/TraceServiceCell.vue'
 import DurationBarCell from '~/components/data/cells/DurationBarCell.vue'
 import { useTracesPage } from './usePage'
 import { buildSpansExport, downloadOtlpJson, type TraceSpans } from '~/lib/otlpExport'
+import { buildTraceTrees, downloadText } from '~/lib/textExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -137,22 +138,41 @@ async function fetchTraceSpansBounded(ids: string[]): Promise<TraceSpans[]> {
   return out
 }
 
-async function exportTraces() {
+// Both export formats share the same fetch: the only difference is the
+// serialiser at the end. Keeping the fetch in a thunk means switching
+// formats from the dropdown doesn't re-issue every detail call.
+async function exportTracesWith(serialise: (traces: TraceSpans[]) => void) {
   if (page.items.value.length === 0 || isExporting.value) return
   isExporting.value = true
   try {
     const ids = page.items.value.map(r => r.traceId)
     const traces = await fetchTraceSpansBounded(ids)
     if (traces.length === 0) return
-    const envelope = buildSpansExport(traces)
-    downloadOtlpJson(envelope, 'traces')
+    serialise(traces)
   } finally {
     isExporting.value = false
   }
 }
 
+function exportTracesOtlp() {
+  return exportTracesWith(traces => downloadOtlpJson(buildSpansExport(traces), 'traces'))
+}
+function exportTracesTree() {
+  return exportTracesWith(traces => downloadText(buildTraceTrees(traces), 'traces', 'txt'))
+}
+
 const actions: ActionDescriptor[] = [
-  { kind: 'custom', labelKey: 'traces.exportOtlp', icon: 'i-ph-download-simple', onClick: exportTraces, loading: isExporting, disabled: exportDisabled },
+  {
+    kind: 'split',
+    labelKey: 'traces.export.otlp',
+    icon: 'i-ph-download-simple',
+    onClick: exportTracesOtlp,
+    loading: isExporting,
+    disabled: exportDisabled,
+    items: [
+      { labelKey: 'traces.export.tree', icon: 'i-ph-tree-view', onClick: exportTracesTree }
+    ]
+  },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },
   { kind: 'live', isLive: page.isLive, onToggle: page.toggleLive }
 ]

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -8,6 +8,7 @@ import TraceStatusBadgeCell from '~/components/data/cells/TraceStatusBadgeCell.v
 import TraceServiceCell from '~/components/data/cells/TraceServiceCell.vue'
 import DurationBarCell from '~/components/data/cells/DurationBarCell.vue'
 import { useTracesPage } from './usePage'
+import { buildSpansExport, downloadOtlpJson, type TraceSpans } from '~/lib/otlpExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -106,7 +107,52 @@ const filters: FilterDescriptor[] = [
   { kind: 'limit', modelValue: page.limit, disabled: page.isLive }
 ]
 
+// Trace summaries only carry the root span info; the OTLP envelope needs
+// every span, so we fan out detail fetches with a small concurrency cap
+// (good citizenship toward the API and the browser's connection pool).
+// Failures on individual traces are swallowed and skipped — the export is
+// best-effort, the same way the metrics-tree export is.
+const EXPORT_CONCURRENCY = 6
+const isExporting = ref(false)
+const exportDisabled = computed(() => page.items.value.length === 0 || isExporting.value)
+
+async function fetchTraceSpansBounded(ids: string[]): Promise<TraceSpans[]> {
+  const out: TraceSpans[] = []
+  let cursor = 0
+  async function worker() {
+    while (cursor < ids.length) {
+      const idx = cursor++
+      const id = ids[idx]!
+      try {
+        const detail = await $traceService.getTrace(id)
+        out.push({ traceId: detail.traceId, spans: detail.spans })
+      } catch {
+        // Drop the trace from the export rather than aborting — matches the
+        // "best-effort" behaviour the rest of the page already follows for
+        // transient backend errors.
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(EXPORT_CONCURRENCY, ids.length) }, worker))
+  return out
+}
+
+async function exportTraces() {
+  if (page.items.value.length === 0 || isExporting.value) return
+  isExporting.value = true
+  try {
+    const ids = page.items.value.map(r => r.traceId)
+    const traces = await fetchTraceSpansBounded(ids)
+    if (traces.length === 0) return
+    const envelope = buildSpansExport(traces)
+    downloadOtlpJson(envelope, 'traces')
+  } finally {
+    isExporting.value = false
+  }
+}
+
 const actions: ActionDescriptor[] = [
+  { kind: 'custom', labelKey: 'traces.exportOtlp', icon: 'i-ph-download-simple', onClick: exportTraces, loading: isExporting, disabled: exportDisabled },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },
   { kind: 'live', isLive: page.isLive, onToggle: page.toggleLive }
 ]

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -9,7 +9,7 @@ import TraceServiceCell from '~/components/data/cells/TraceServiceCell.vue'
 import DurationBarCell from '~/components/data/cells/DurationBarCell.vue'
 import { useTracesPage } from './usePage'
 import { buildSpansExport, downloadOtlpJson, type TraceSpans } from '~/lib/otlpExport'
-import { buildTraceTrees, downloadText } from '~/lib/textExport'
+import { buildTraceTrees, buildTracesCsv, downloadText } from '~/lib/textExport'
 import type {
   ActionDescriptor,
   FilterDescriptor
@@ -160,6 +160,12 @@ function exportTracesOtlp() {
 function exportTracesTree() {
   return exportTracesWith(traces => downloadText(buildTraceTrees(traces), 'traces', 'txt'))
 }
+// CSV is the on-screen grid: only the summaries are needed, no per-trace
+// detail fetch — same `page.items` the table already renders.
+function exportTracesCsv() {
+  if (page.items.value.length === 0) return
+  downloadText(buildTracesCsv(page.items.value), 'traces', 'csv')
+}
 
 const actions: ActionDescriptor[] = [
   {
@@ -170,7 +176,8 @@ const actions: ActionDescriptor[] = [
     loading: isExporting,
     disabled: exportDisabled,
     items: [
-      { labelKey: 'traces.export.tree', icon: 'i-ph-tree-view', onClick: exportTracesTree }
+      { labelKey: 'traces.export.tree', icon: 'i-ph-tree-view', onClick: exportTracesTree },
+      { labelKey: 'traces.export.csv', icon: 'i-ph-file-csv', onClick: exportTracesCsv }
     ]
   },
   { kind: 'refresh', loading: page.isLoading, disabled: page.isLive, onClick: page.reload },

--- a/web/app/types/toolbar.ts
+++ b/web/app/types/toolbar.ts
@@ -104,6 +104,7 @@ export type ActionDescriptor =
   | RefreshActionDescriptor
   | LiveActionDescriptor
   | CustomActionDescriptor
+  | SplitActionDescriptor
 
 export interface RefreshActionDescriptor {
   kind: 'refresh'
@@ -123,6 +124,25 @@ export interface CustomActionDescriptor {
   labelKey: string
   icon: string
   onClick: () => void
+  variant?: 'solid' | 'subtle' | 'ghost' | 'outline'
+  color?: 'primary' | 'neutral' | 'success' | 'warning' | 'error'
+  loading?: Ref<boolean>
+  disabled?: Ref<boolean>
+}
+
+/**
+ * Split button: primary action on the left, dropdown caret on the right
+ * exposing secondary actions. Modelled after the Azure DevOps PR action
+ * button — one click for the most common case, one extra click for the
+ * variants. Loading/disabled apply to the whole control so the user can't
+ * trigger the primary or a secondary while one is already in flight.
+ */
+export interface SplitActionDescriptor {
+  kind: 'split'
+  labelKey: string
+  icon: string
+  onClick: () => void
+  items: Array<{ labelKey: string; icon?: string; onClick: () => void }>
   variant?: 'solid' | 'subtle' | 'ghost' | 'outline'
   color?: 'primary' | 'neutral' | 'success' | 'warning' | 'error'
   loading?: Ref<boolean>

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -330,7 +330,8 @@
     "errorTitle": "Failed to load logs",
     "export": {
       "otlp": "Export OTLP",
-      "logfmt": "Export as logfmt (.log)"
+      "logfmt": "Export as logfmt (.log)",
+      "csv": "Export as CSV (.csv)"
     },
     "col": {
       "time": "Time",
@@ -367,7 +368,8 @@
     "errorTitle": "Failed to load traces",
     "export": {
       "otlp": "Export OTLP",
-      "tree": "Export as tree text (.txt)"
+      "tree": "Export as tree text (.txt)",
+      "csv": "Export as CSV (.csv)"
     },
     "col": {
       "start": "Start",

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -327,6 +327,7 @@
     "emptyTitle": "No logs in the selected window",
     "emptyDescription": "Adjust the time range or filters, or send events to the OTLP receiver.",
     "errorTitle": "Failed to load logs",
+    "exportOtlp": "Export OTLP",
     "col": {
       "time": "Time",
       "service": "Application",
@@ -360,6 +361,7 @@
     "emptyTitle": "No traces in the selected window",
     "emptyDescription": "Adjust the time range or filters, or send traces to the OTLP receiver.",
     "errorTitle": "Failed to load traces",
+    "exportOtlp": "Export OTLP",
     "col": {
       "start": "Start",
       "service": "Application",
@@ -375,6 +377,7 @@
     "detail": {
       "back": "Back to traces",
       "viewLogs": "View logs",
+      "exportOtlp": "Export OTLP",
       "spanCount": "{count} spans",
       "spans": "Spans",
       "spanDetail": "Span detail",

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "retry": "Retry",
     "copy": "Copy",
     "copied": "Copied",
+    "moreOptions": "More options",
     "all": "All",
     "none": "None",
     "select": "Select",
@@ -327,7 +328,10 @@
     "emptyTitle": "No logs in the selected window",
     "emptyDescription": "Adjust the time range or filters, or send events to the OTLP receiver.",
     "errorTitle": "Failed to load logs",
-    "exportOtlp": "Export OTLP",
+    "export": {
+      "otlp": "Export OTLP",
+      "logfmt": "Export as logfmt (.log)"
+    },
     "col": {
       "time": "Time",
       "service": "Application",
@@ -361,7 +365,10 @@
     "emptyTitle": "No traces in the selected window",
     "emptyDescription": "Adjust the time range or filters, or send traces to the OTLP receiver.",
     "errorTitle": "Failed to load traces",
-    "exportOtlp": "Export OTLP",
+    "export": {
+      "otlp": "Export OTLP",
+      "tree": "Export as tree text (.txt)"
+    },
     "col": {
       "start": "Start",
       "service": "Application",
@@ -377,7 +384,10 @@
     "detail": {
       "back": "Back to traces",
       "viewLogs": "View logs",
-      "exportOtlp": "Export OTLP",
+      "export": {
+        "otlp": "Export OTLP",
+        "tree": "Export as tree text (.txt)"
+      },
       "spanCount": "{count} spans",
       "spans": "Spans",
       "spanDetail": "Span detail",

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -17,6 +17,7 @@
     "retry": "Retry",
     "copy": "Copy",
     "copied": "Copied",
+    "copyFailed": "Copy failed",
     "moreOptions": "More options",
     "all": "All",
     "none": "None",
@@ -331,7 +332,8 @@
     "export": {
       "otlp": "Export OTLP",
       "logfmt": "Export as logfmt (.log)",
-      "csv": "Export as CSV (.csv)"
+      "csv": "Export as CSV (.csv)",
+      "clipboard": "Copy to clipboard"
     },
     "col": {
       "time": "Time",
@@ -369,7 +371,8 @@
     "export": {
       "otlp": "Export OTLP",
       "tree": "Export as tree text (.txt)",
-      "csv": "Export as CSV (.csv)"
+      "csv": "Export as CSV (.csv)",
+      "clipboard": "Copy to clipboard"
     },
     "col": {
       "start": "Start",
@@ -388,7 +391,8 @@
       "viewLogs": "View logs",
       "export": {
         "otlp": "Export OTLP",
-        "tree": "Export as tree text (.txt)"
+        "tree": "Export as tree text (.txt)",
+        "clipboard": "Copy to clipboard"
       },
       "spanCount": "{count} spans",
       "spans": "Spans",

--- a/web/i18n/locales/it.json
+++ b/web/i18n/locales/it.json
@@ -328,6 +328,7 @@
     "emptyTitle": "Nessun log nel periodo selezionato",
     "emptyDescription": "Modifica il periodo o i filtri, oppure invia eventi all'OTLP receiver.",
     "errorTitle": "Errore nel caricamento dei log",
+    "exportOtlp": "Esporta OTLP",
     "col": {
       "time": "Ora",
       "service": "Applicazione",
@@ -361,6 +362,7 @@
     "emptyTitle": "Nessuna trace nel periodo selezionato",
     "emptyDescription": "Modifica il periodo o i filtri, oppure invia tracce all'OTLP receiver.",
     "errorTitle": "Errore nel caricamento delle tracce",
+    "exportOtlp": "Esporta OTLP",
     "col": {
       "start": "Inizio",
       "service": "Applicazione",
@@ -376,6 +378,7 @@
     "detail": {
       "back": "Torna alle tracce",
       "viewLogs": "Vai ai log",
+      "exportOtlp": "Esporta OTLP",
       "spanCount": "{count} span",
       "spans": "Span",
       "spanDetail": "Dettaglio span",

--- a/web/i18n/locales/it.json
+++ b/web/i18n/locales/it.json
@@ -331,7 +331,8 @@
     "errorTitle": "Errore nel caricamento dei log",
     "export": {
       "otlp": "Esporta OTLP",
-      "logfmt": "Esporta come logfmt (.log)"
+      "logfmt": "Esporta come logfmt (.log)",
+      "csv": "Esporta come CSV (.csv)"
     },
     "col": {
       "time": "Ora",
@@ -368,7 +369,8 @@
     "errorTitle": "Errore nel caricamento delle tracce",
     "export": {
       "otlp": "Esporta OTLP",
-      "tree": "Esporta come albero testuale (.txt)"
+      "tree": "Esporta come albero testuale (.txt)",
+      "csv": "Esporta come CSV (.csv)"
     },
     "col": {
       "start": "Inizio",

--- a/web/i18n/locales/it.json
+++ b/web/i18n/locales/it.json
@@ -17,6 +17,7 @@
     "retry": "Riprova",
     "copy": "Copia",
     "copied": "Copiato",
+    "moreOptions": "Altre opzioni",
     "all": "Tutti",
     "none": "Nessuno",
     "select": "Seleziona",
@@ -328,7 +329,10 @@
     "emptyTitle": "Nessun log nel periodo selezionato",
     "emptyDescription": "Modifica il periodo o i filtri, oppure invia eventi all'OTLP receiver.",
     "errorTitle": "Errore nel caricamento dei log",
-    "exportOtlp": "Esporta OTLP",
+    "export": {
+      "otlp": "Esporta OTLP",
+      "logfmt": "Esporta come logfmt (.log)"
+    },
     "col": {
       "time": "Ora",
       "service": "Applicazione",
@@ -362,7 +366,10 @@
     "emptyTitle": "Nessuna trace nel periodo selezionato",
     "emptyDescription": "Modifica il periodo o i filtri, oppure invia tracce all'OTLP receiver.",
     "errorTitle": "Errore nel caricamento delle tracce",
-    "exportOtlp": "Esporta OTLP",
+    "export": {
+      "otlp": "Esporta OTLP",
+      "tree": "Esporta come albero testuale (.txt)"
+    },
     "col": {
       "start": "Inizio",
       "service": "Applicazione",
@@ -378,7 +385,10 @@
     "detail": {
       "back": "Torna alle tracce",
       "viewLogs": "Vai ai log",
-      "exportOtlp": "Esporta OTLP",
+      "export": {
+        "otlp": "Esporta OTLP",
+        "tree": "Esporta come albero testuale (.txt)"
+      },
       "spanCount": "{count} span",
       "spans": "Span",
       "spanDetail": "Dettaglio span",

--- a/web/i18n/locales/it.json
+++ b/web/i18n/locales/it.json
@@ -17,6 +17,7 @@
     "retry": "Riprova",
     "copy": "Copia",
     "copied": "Copiato",
+    "copyFailed": "Copia non riuscita",
     "moreOptions": "Altre opzioni",
     "all": "Tutti",
     "none": "Nessuno",
@@ -332,7 +333,8 @@
     "export": {
       "otlp": "Esporta OTLP",
       "logfmt": "Esporta come logfmt (.log)",
-      "csv": "Esporta come CSV (.csv)"
+      "csv": "Esporta come CSV (.csv)",
+      "clipboard": "Copia negli appunti"
     },
     "col": {
       "time": "Ora",
@@ -370,7 +372,8 @@
     "export": {
       "otlp": "Esporta OTLP",
       "tree": "Esporta come albero testuale (.txt)",
-      "csv": "Esporta come CSV (.csv)"
+      "csv": "Esporta come CSV (.csv)",
+      "clipboard": "Copia negli appunti"
     },
     "col": {
       "start": "Inizio",
@@ -389,7 +392,8 @@
       "viewLogs": "Vai ai log",
       "export": {
         "otlp": "Esporta OTLP",
-        "tree": "Esporta come albero testuale (.txt)"
+        "tree": "Esporta come albero testuale (.txt)",
+        "clipboard": "Copia negli appunti"
       },
       "spanCount": "{count} span",
       "spans": "Span",

--- a/web/tests/lib/otlpExport.spec.ts
+++ b/web/tests/lib/otlpExport.spec.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildLogsExport,
+  buildSpansExport,
+  isoToUnixNano
+} from '~/lib/otlpExport'
+import type { LogRecordDto, SpanDto } from '~/services/types'
+
+function log(partial: Partial<LogRecordDto> = {}): LogRecordDto {
+  return {
+    time: '2026-05-23T12:00:00.000Z',
+    observedTime: null,
+    severityNumber: 9,
+    severityText: 'Info',
+    body: 'hello',
+    traceId: null,
+    spanId: null,
+    scopeName: 'app.requests',
+    scopeVersion: '1.0.0',
+    resourceHash: 'aaaa',
+    serviceName: 'svc-a',
+    attributes: {},
+    ...partial
+  }
+}
+
+function span(partial: Partial<SpanDto> = {}): SpanDto {
+  return {
+    spanId: '0102030405060708',
+    parentSpanId: null,
+    name: 'GET /things',
+    kind: 'Server',
+    start: '2026-05-23T12:00:00.000Z',
+    end: '2026-05-23T12:00:01.000Z',
+    durationMs: 1000,
+    statusCode: 'Ok',
+    statusMessage: null,
+    scopeName: 'app.requests',
+    scopeVersion: '1.0.0',
+    serviceName: 'svc-a',
+    attributes: {},
+    events: [],
+    links: [],
+    ...partial
+  }
+}
+
+describe('isoToUnixNano', () => {
+  it('converts millisecond-precision UTC', () => {
+    // 1970-01-01T00:00:00.001Z = 1ms = 1_000_000ns
+    expect(isoToUnixNano('1970-01-01T00:00:00.001Z')).toBe('1000000')
+  })
+
+  it('preserves sub-millisecond precision (100ns ticks from .NET)', () => {
+    // Source: epoch + 1.1234567s = 1_123_456_700ns
+    expect(isoToUnixNano('1970-01-01T00:00:01.1234567Z')).toBe('1123456700')
+  })
+
+  it('handles ISO without fractional seconds', () => {
+    expect(isoToUnixNano('1970-01-01T00:00:02Z')).toBe('2000000000')
+  })
+
+  it('treats unsuffixed ISO as UTC', () => {
+    expect(isoToUnixNano('1970-01-01T00:00:00.5')).toBe('500000000')
+  })
+
+  it('returns 0 for unparseable input', () => {
+    expect(isoToUnixNano('not a date')).toBe('0')
+  })
+})
+
+describe('buildLogsExport', () => {
+  it('wraps the result in an OTLP envelope', () => {
+    const out = buildLogsExport([log()])
+    expect(out).toHaveProperty('resourceLogs')
+    expect(Array.isArray(out.resourceLogs)).toBe(true)
+  })
+
+  it('groups records by (resourceHash + serviceName) then by scope', () => {
+    const out = buildLogsExport([
+      log({ resourceHash: 'aaaa', serviceName: 'svc-a', scopeName: 's1' }),
+      log({ resourceHash: 'aaaa', serviceName: 'svc-a', scopeName: 's2' }),
+      log({ resourceHash: 'bbbb', serviceName: 'svc-b', scopeName: 's1' })
+    ])
+    expect(out.resourceLogs).toHaveLength(2)
+    const a = out.resourceLogs.find(r =>
+      r.resource.attributes.some(a => a.key === 'service.name' && a.value.stringValue === 'svc-a'))!
+    expect(a.scopeLogs).toHaveLength(2)
+    expect(a.scopeLogs.map(s => s.scope.name).sort()).toEqual(['s1', 's2'])
+  })
+
+  it('encodes service.name and dashboard.resource_hash as resource attributes', () => {
+    const out = buildLogsExport([log({ resourceHash: 'fp123', serviceName: 'svc-x' })])
+    const attrs = out.resourceLogs[0]!.resource.attributes
+    const byKey = Object.fromEntries(attrs.map(a => [a.key, a.value]))
+    expect(byKey['service.name']).toEqual({ stringValue: 'svc-x' })
+    expect(byKey['dashboard.resource_hash']).toEqual({ stringValue: 'fp123' })
+  })
+
+  it('emits timeUnixNano as a string', () => {
+    const out = buildLogsExport([log({ time: '2026-05-23T12:34:56.000Z' })])
+    const t = out.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.timeUnixNano
+    expect(typeof t).toBe('string')
+    expect(t).toMatch(/^\d+$/)
+  })
+
+  it('keeps the log body under value.stringValue', () => {
+    const out = buildLogsExport([log({ body: 'connection refused' })])
+    const body = out.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.body
+    expect(body).toEqual({ stringValue: 'connection refused' })
+  })
+
+  it('threads severity and trace/span correlation through', () => {
+    const out = buildLogsExport([log({
+      severityNumber: 17,
+      severityText: 'Error',
+      traceId: 'aabbccddeeff00112233445566778899',
+      spanId: '0102030405060708'
+    })])
+    const rec = out.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!
+    expect(rec.severityNumber).toBe(17)
+    expect(rec.severityText).toBe('Error')
+    expect(rec.traceId).toBe('aabbccddeeff00112233445566778899')
+    expect(rec.spanId).toBe('0102030405060708')
+  })
+
+  it('encodes attribute values using OTLP AnyValue', () => {
+    const out = buildLogsExport([log({
+      attributes: {
+        s: 'str',
+        b: true,
+        i: 42,
+        f: 3.14,
+        arr: ['a', 1],
+        obj: { nested: 'v' },
+        nope: null
+      }
+    })])
+    const attrs = out.resourceLogs[0]!.scopeLogs[0]!.logRecords[0]!.attributes
+    const byKey = Object.fromEntries(attrs.map(a => [a.key, a.value]))
+    expect(byKey.s).toEqual({ stringValue: 'str' })
+    expect(byKey.b).toEqual({ boolValue: true })
+    expect(byKey.i).toEqual({ intValue: '42' })
+    expect(byKey.f).toEqual({ doubleValue: 3.14 })
+    expect(byKey.arr).toEqual({ arrayValue: { values: [{ stringValue: 'a' }, { intValue: '1' }] } })
+    expect(byKey.obj).toEqual({ kvlistValue: { values: [{ key: 'nested', value: { stringValue: 'v' } }] } })
+    // null/undefined attributes are dropped so the OTLP value stays well-formed.
+    expect(byKey.nope).toBeUndefined()
+  })
+})
+
+describe('buildSpansExport', () => {
+  it('wraps the result in an OTLP envelope', () => {
+    const out = buildSpansExport([{ traceId: 't1', spans: [span()] }])
+    expect(out).toHaveProperty('resourceSpans')
+  })
+
+  it('groups spans by serviceName then by scope', () => {
+    const out = buildSpansExport([
+      { traceId: 't1', spans: [
+        span({ serviceName: 'svc-a', scopeName: 's1' }),
+        span({ serviceName: 'svc-a', scopeName: 's2', spanId: '0a' }),
+        span({ serviceName: 'svc-b', scopeName: 's1', spanId: '0b' })
+      ] }
+    ])
+    expect(out.resourceSpans).toHaveLength(2)
+    const a = out.resourceSpans.find(r =>
+      r.resource.attributes.some(a => a.key === 'service.name' && a.value.stringValue === 'svc-a'))!
+    expect(a.scopeSpans).toHaveLength(2)
+  })
+
+  it('tags every emitted span with its trace id', () => {
+    const out = buildSpansExport([
+      { traceId: 'ta', spans: [span({ spanId: 's-a' })] },
+      { traceId: 'tb', spans: [span({ spanId: 's-b' })] }
+    ])
+    const allSpans = out.resourceSpans.flatMap(r => r.scopeSpans.flatMap(s => s.spans))
+    const idMap = Object.fromEntries(allSpans.map(s => [s.spanId, s.traceId]))
+    expect(idMap['s-a']).toBe('ta')
+    expect(idMap['s-b']).toBe('tb')
+  })
+
+  it('maps span kind and status to OTLP enum names', () => {
+    const out = buildSpansExport([{
+      traceId: 't1',
+      spans: [
+        span({ spanId: 's1', kind: 'Server', statusCode: 'Ok' }),
+        span({ spanId: 's2', kind: 'Client', statusCode: 'Error', statusMessage: 'boom' }),
+        span({ spanId: 's3', kind: 'Internal', statusCode: 'Unset' })
+      ]
+    }])
+    const allSpans = out.resourceSpans.flatMap(r => r.scopeSpans.flatMap(s => s.spans))
+    const byId = Object.fromEntries(allSpans.map(s => [s.spanId, s]))
+    expect(byId.s1!.kind).toBe('SPAN_KIND_SERVER')
+    expect(byId.s1!.status).toEqual({ code: 'STATUS_CODE_OK' })
+    expect(byId.s2!.kind).toBe('SPAN_KIND_CLIENT')
+    expect(byId.s2!.status).toEqual({ code: 'STATUS_CODE_ERROR', message: 'boom' })
+    expect(byId.s3!.status).toEqual({ code: 'STATUS_CODE_UNSET' })
+  })
+
+  it('passes start/end as nanosecond strings', () => {
+    const out = buildSpansExport([{
+      traceId: 't1',
+      spans: [span({ start: '2026-05-23T12:00:00.000Z', end: '2026-05-23T12:00:01.000Z' })]
+    }])
+    const s = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(typeof s.startTimeUnixNano).toBe('string')
+    expect(typeof s.endTimeUnixNano).toBe('string')
+    expect(BigInt(s.endTimeUnixNano) - BigInt(s.startTimeUnixNano)).toBe(1_000_000_000n)
+  })
+
+  it('copies events and links verbatim, encoding attributes as KeyValue', () => {
+    const out = buildSpansExport([{
+      traceId: 't1',
+      spans: [span({
+        events: [{ name: 'log', time: '2026-05-23T12:00:00.500Z', attributes: { x: 1 } }],
+        links: [{ traceId: 't2', spanId: 'sx', attributes: { rel: 'follows' } }]
+      })]
+    }])
+    const s = out.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(s.events).toEqual([
+      { timeUnixNano: '1779537600500000000', name: 'log', attributes: [{ key: 'x', value: { intValue: '1' } }] }
+    ])
+    expect(s.links).toEqual([
+      { traceId: 't2', spanId: 'sx', attributes: [{ key: 'rel', value: { stringValue: 'follows' } }] }
+    ])
+  })
+})

--- a/web/tests/lib/textExport.spec.ts
+++ b/web/tests/lib/textExport.spec.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import { buildLogfmt, buildTraceTree, buildTraceTrees } from '~/lib/textExport'
+import type { LogRecordDto, SpanDto } from '~/services/types'
+
+function log(partial: Partial<LogRecordDto> = {}): LogRecordDto {
+  return {
+    time: '2026-05-23T12:00:00.000Z',
+    observedTime: null,
+    severityNumber: 9,
+    severityText: 'Info',
+    body: 'hello',
+    traceId: null,
+    spanId: null,
+    scopeName: 'app.requests',
+    scopeVersion: '1.0.0',
+    resourceHash: 'aaaa',
+    serviceName: 'svc-a',
+    attributes: {},
+    ...partial
+  }
+}
+
+function span(partial: Partial<SpanDto> = {}): SpanDto {
+  return {
+    spanId: 's1',
+    parentSpanId: null,
+    name: 'GET /things',
+    kind: 'Server',
+    start: '2026-05-23T12:00:00.000Z',
+    end: '2026-05-23T12:00:00.150Z',
+    durationMs: 150,
+    statusCode: 'Ok',
+    statusMessage: null,
+    scopeName: 'app.requests',
+    scopeVersion: '1.0.0',
+    serviceName: 'svc-a',
+    attributes: {},
+    events: [],
+    links: [],
+    ...partial
+  }
+}
+
+describe('buildLogfmt', () => {
+  it('renders one line per record', () => {
+    const out = buildLogfmt([log({ body: 'a' }), log({ body: 'b' })])
+    expect(out.trimEnd().split('\n')).toHaveLength(2)
+  })
+
+  it('puts time, level, service, scope, msg in the expected order', () => {
+    const out = buildLogfmt([log({ body: 'hi', severityText: 'Warn' })]).trim()
+    expect(out).toBe(
+      'time=2026-05-23T12:00:00.000Z level=Warn service=svc-a scope=app.requests msg=hi'
+    )
+  })
+
+  it('quotes values containing spaces, equals, quotes, or backslashes', () => {
+    const out = buildLogfmt([log({ body: 'connection refused' })]).trim()
+    expect(out).toContain('msg="connection refused"')
+
+    const out2 = buildLogfmt([log({ body: 'a"b\\c' })]).trim()
+    expect(out2).toContain('msg="a\\"b\\\\c"')
+  })
+
+  it('escapes newlines so each record stays on one line', () => {
+    const out = buildLogfmt([log({ body: 'first\nsecond' })]).trim()
+    expect(out.split('\n')).toHaveLength(1)
+    expect(out).toContain('msg="first\\nsecond"')
+  })
+
+  it('renders trace_id/span_id correlation when present', () => {
+    const out = buildLogfmt([log({
+      traceId: 'aabbccdd',
+      spanId: '01020304'
+    })]).trim()
+    expect(out).toContain('trace_id=aabbccdd')
+    expect(out).toContain('span_id=01020304')
+  })
+
+  it('namespaces attributes under attr.* and drops null/undefined', () => {
+    const out = buildLogfmt([log({
+      attributes: {
+        user_id: 42,
+        feature: 'beta',
+        empty: null,
+        missing: undefined
+      }
+    })]).trim()
+    expect(out).toContain('attr.user_id=42')
+    expect(out).toContain('attr.feature=beta')
+    expect(out).not.toContain('attr.empty')
+    expect(out).not.toContain('attr.missing')
+  })
+
+  it('flattens nested attribute values to JSON', () => {
+    const out = buildLogfmt([log({
+      attributes: { tags: ['a', 'b'], nested: { k: 1 } }
+    })]).trim()
+    expect(out).toContain('attr.tags="[\\"a\\",\\"b\\"]"')
+    expect(out).toContain('attr.nested="{\\"k\\":1}"')
+  })
+
+  it('returns an empty string for an empty input', () => {
+    expect(buildLogfmt([])).toBe('')
+  })
+
+  it('falls back to numeric severity when the text label is absent', () => {
+    const out = buildLogfmt([log({ severityText: null, severityNumber: 13 })]).trim()
+    expect(out).toContain('level=13')
+  })
+})
+
+describe('buildTraceTree', () => {
+  it('renders a single-span trace with a header line', () => {
+    const out = buildTraceTree({ traceId: 't1', spans: [span()] }).trim().split('\n')
+    expect(out[0]).toContain('trace=t1')
+    expect(out[0]).toContain('spans=1')
+    expect(out[1]).toContain('- GET /things')
+    expect(out[1]).toContain('[server ok 150.0ms]')
+    expect(out[1]).toContain('service=svc-a')
+  })
+
+  it('nests children under their parent by two-space indent', () => {
+    const out = buildTraceTree({
+      traceId: 't1',
+      spans: [
+        span({ spanId: 'root', name: 'root' }),
+        span({ spanId: 'child', parentSpanId: 'root', name: 'child' }),
+        span({ spanId: 'grand', parentSpanId: 'child', name: 'grand' })
+      ]
+    })
+    const lines = out.split('\n')
+    const rootLine = lines.find(l => l.includes('- root'))!
+    const childLine = lines.find(l => l.includes('- child'))!
+    const grandLine = lines.find(l => l.includes('- grand'))!
+    expect(rootLine.startsWith('- ')).toBe(true)
+    expect(childLine.startsWith('  - ')).toBe(true)
+    expect(grandLine.startsWith('    - ')).toBe(true)
+  })
+
+  it('orders siblings by start time', () => {
+    const out = buildTraceTree({
+      traceId: 't1',
+      spans: [
+        span({ spanId: 'p', name: 'p' }),
+        span({ spanId: 'b', parentSpanId: 'p', name: 'second', start: '2026-05-23T12:00:00.200Z' }),
+        span({ spanId: 'a', parentSpanId: 'p', name: 'first', start: '2026-05-23T12:00:00.100Z' })
+      ]
+    })
+    const lines = out.split('\n').filter(l => l.includes('- '))
+    const aIdx = lines.findIndex(l => l.includes('first'))
+    const bIdx = lines.findIndex(l => l.includes('second'))
+    expect(aIdx).toBeLessThan(bIdx)
+  })
+
+  it('promotes orphans (missing parent) to depth 0', () => {
+    const out = buildTraceTree({
+      traceId: 't1',
+      spans: [span({ spanId: 'orphan', parentSpanId: 'missing', name: 'orphan' })]
+    })
+    expect(out).toContain('\n- orphan')
+  })
+
+  it('surfaces status message under attr.error when status is Error', () => {
+    const out = buildTraceTree({
+      traceId: 't1',
+      spans: [span({ statusCode: 'Error', statusMessage: 'boom' })]
+    })
+    expect(out).toContain('[server error 150.0ms]')
+    expect(out).toContain('error=boom')
+  })
+
+  it('renders a placeholder for a trace with no spans', () => {
+    const out = buildTraceTree({ traceId: 't1', spans: [] })
+    expect(out).toContain('spans=0')
+    expect(out).toContain('(no spans)')
+  })
+})
+
+describe('buildTraceTrees', () => {
+  it('joins multiple traces with a blank line separator', () => {
+    const out = buildTraceTrees([
+      { traceId: 't1', spans: [span({ spanId: 's1' })] },
+      { traceId: 't2', spans: [span({ spanId: 's2' })] }
+    ])
+    // Each trace block ends with "\n", and they are joined with "\n",
+    // producing a blank line between blocks.
+    expect(out).toMatch(/trace=t1[\s\S]+\n\ntrace=t2/)
+  })
+})

--- a/web/tests/lib/textExport.spec.ts
+++ b/web/tests/lib/textExport.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { buildLogfmt, buildTraceTree, buildTraceTrees } from '~/lib/textExport'
-import type { LogRecordDto, SpanDto } from '~/services/types'
+import {
+  buildLogfmt,
+  buildLogsCsv,
+  buildTraceTree,
+  buildTraceTrees,
+  buildTracesCsv
+} from '~/lib/textExport'
+import type { LogRecordDto, SpanDto, TraceSummaryDto } from '~/services/types'
 
 function log(partial: Partial<LogRecordDto> = {}): LogRecordDto {
   return {
@@ -186,5 +192,87 @@ describe('buildTraceTrees', () => {
     // Each trace block ends with "\n", and they are joined with "\n",
     // producing a blank line between blocks.
     expect(out).toMatch(/trace=t1[\s\S]+\n\ntrace=t2/)
+  })
+})
+
+function traceSummary(partial: Partial<TraceSummaryDto> = {}): TraceSummaryDto {
+  return {
+    traceId: 't1',
+    rootSpanName: 'GET /things',
+    start: '2026-05-23T12:00:00.000Z',
+    end: '2026-05-23T12:00:00.150Z',
+    durationMs: 150,
+    spanCount: 4,
+    rootStatusCode: 'Ok',
+    resourceHash: 'aaaa',
+    serviceName: 'svc-a',
+    otherServiceNames: [],
+    ...partial
+  }
+}
+
+describe('buildLogsCsv', () => {
+  it('emits a header row even when there are no records', () => {
+    const out = buildLogsCsv([])
+    expect(out.trim()).toBe('time,service,severity,scope,trace_id,span_id,body')
+  })
+
+  it('renders columns in the on-screen order: time, service, severity, scope, trace_id, span_id, body', () => {
+    const out = buildLogsCsv([log({
+      body: 'hello',
+      severityText: 'Warn',
+      traceId: 'tt',
+      spanId: 'ss'
+    })])
+    const lines = out.trim().split('\n')
+    expect(lines[0]).toBe('time,service,severity,scope,trace_id,span_id,body')
+    expect(lines[1]).toBe('2026-05-23T12:00:00.000Z,svc-a,Warn,app.requests,tt,ss,hello')
+  })
+
+  it('quotes fields containing commas, quotes, or newlines (RFC 4180)', () => {
+    const out = buildLogsCsv([log({ body: 'a,b' })])
+    expect(out).toContain(',"a,b"\n')
+
+    const out2 = buildLogsCsv([log({ body: 'say "hi"' })])
+    expect(out2).toContain(',"say ""hi"""\n')
+
+    const out3 = buildLogsCsv([log({ body: 'first\nsecond' })])
+    expect(out3).toContain(',"first\nsecond"\n')
+  })
+
+  it('leaves empty values blank rather than quoted', () => {
+    const out = buildLogsCsv([log({ serviceName: null, scopeName: null, traceId: null, spanId: null, body: null })])
+    const row = out.trim().split('\n')[1]!
+    expect(row).toBe('2026-05-23T12:00:00.000Z,,Info,,,,')
+  })
+
+  it('falls back to severity number when text is absent', () => {
+    const out = buildLogsCsv([log({ severityText: null, severityNumber: 13 })])
+    expect(out.trim().split('\n')[1]).toContain(',13,')
+  })
+})
+
+describe('buildTracesCsv', () => {
+  it('emits a header row even when there are no records', () => {
+    const out = buildTracesCsv([])
+    expect(out.trim()).toBe('start,service,root_span,duration_ms,spans,status,trace_id')
+  })
+
+  it('renders columns in the on-screen order: start, service, root_span, duration_ms, spans, status, trace_id', () => {
+    const out = buildTracesCsv([traceSummary()])
+    const lines = out.trim().split('\n')
+    expect(lines[0]).toBe('start,service,root_span,duration_ms,spans,status,trace_id')
+    expect(lines[1]).toBe('2026-05-23T12:00:00.000Z,svc-a,GET /things,150,4,Ok,t1')
+  })
+
+  it('quotes a root span name containing a comma', () => {
+    const out = buildTracesCsv([traceSummary({ rootSpanName: 'GET /a, /b' })])
+    expect(out).toContain(',"GET /a, /b",')
+  })
+
+  it('leaves service blank when null', () => {
+    const out = buildTracesCsv([traceSummary({ serviceName: null })])
+    const row = out.trim().split('\n')[1]!
+    expect(row).toBe('2026-05-23T12:00:00.000Z,,GET /things,150,4,Ok,t1')
   })
 })

--- a/web/tests/lib/textExport.spec.ts
+++ b/web/tests/lib/textExport.spec.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildClipboardMarkdown,
   buildLogfmt,
   buildLogsCsv,
   buildTraceTree,
   buildTraceTrees,
-  buildTracesCsv
+  buildTracesCsv,
+  buildTracesSummaryList
 } from '~/lib/textExport'
 import type { LogRecordDto, SpanDto, TraceSummaryDto } from '~/services/types'
 
@@ -83,29 +85,6 @@ describe('buildLogfmt', () => {
     expect(out).toContain('span_id=01020304')
   })
 
-  it('namespaces attributes under attr.* and drops null/undefined', () => {
-    const out = buildLogfmt([log({
-      attributes: {
-        user_id: 42,
-        feature: 'beta',
-        empty: null,
-        missing: undefined
-      }
-    })]).trim()
-    expect(out).toContain('attr.user_id=42')
-    expect(out).toContain('attr.feature=beta')
-    expect(out).not.toContain('attr.empty')
-    expect(out).not.toContain('attr.missing')
-  })
-
-  it('flattens nested attribute values to JSON', () => {
-    const out = buildLogfmt([log({
-      attributes: { tags: ['a', 'b'], nested: { k: 1 } }
-    })]).trim()
-    expect(out).toContain('attr.tags="[\\"a\\",\\"b\\"]"')
-    expect(out).toContain('attr.nested="{\\"k\\":1}"')
-  })
-
   it('returns an empty string for an empty input', () => {
     expect(buildLogfmt([])).toBe('')
   })
@@ -113,6 +92,29 @@ describe('buildLogfmt', () => {
   it('falls back to numeric severity when the text label is absent', () => {
     const out = buildLogfmt([log({ severityText: null, severityNumber: 13 })]).trim()
     expect(out).toContain('level=13')
+  })
+
+  it('does not emit structured attributes — the compiled msg is enough', () => {
+    // Real-world .NET log: the substituted body is in `msg`, the
+    // attribute map carries the template, the unsubstituted variables,
+    // and OTel-context duplicates. None of that adds signal beyond the
+    // top-level columns, so the line stays compact.
+    const out = buildLogfmt([log({
+      body: 'counter set to 894',
+      traceId: 'aabbcc',
+      spanId: 'ddeeff',
+      attributes: {
+        Value: 894,
+        '{OriginalFormat}': 'counter set to {Value}',
+        SpanId: 'ddeeff',
+        TraceId: 'aabbcc',
+        user_id: 42
+      }
+    })]).trim()
+    expect(out).not.toContain('attr.')
+    expect(out).not.toContain('{OriginalFormat}')
+    // The substituted body still lands intact in `msg`:
+    expect(out).toContain('msg="counter set to 894"')
   })
 })
 
@@ -274,5 +276,55 @@ describe('buildTracesCsv', () => {
     const out = buildTracesCsv([traceSummary({ serviceName: null })])
     const row = out.trim().split('\n')[1]!
     expect(row).toBe('2026-05-23T12:00:00.000Z,,GET /things,150,4,Ok,t1')
+  })
+})
+
+describe('buildClipboardMarkdown', () => {
+  it('wraps the body in a fenced block under a bold title and context lines', () => {
+    const out = buildClipboardMarkdown('OtlpDashboard logs', ['Window: A → B', 'Count: 2 records'], 'time=... msg=hi', 'log')
+    expect(out).toBe(
+      '**OtlpDashboard logs**\n'
+      + 'Window: A → B\n'
+      + 'Count: 2 records\n'
+      + '\n'
+      + '```log\n'
+      + 'time=... msg=hi\n'
+      + '```\n'
+    )
+  })
+
+  it('strips trailing newlines on the body so the closing fence stays tight', () => {
+    const out = buildClipboardMarkdown('t', [], 'body\n\n\n')
+    expect(out).toContain('body\n```\n')
+    expect(out).not.toContain('body\n\n```')
+  })
+
+  it('omits the fence language tag when none is provided', () => {
+    const out = buildClipboardMarkdown('t', [], 'body')
+    expect(out).toContain('```\nbody\n```')
+    expect(out).not.toContain('```undefined')
+  })
+})
+
+describe('buildTracesSummaryList', () => {
+  it('emits one compact line per trace with id-prefix, name, status, duration, spans, service', () => {
+    const out = buildTracesSummaryList([traceSummary({
+      traceId: 'aabbccddeeff00112233445566778899',
+      rootSpanName: 'GET /things',
+      durationMs: 1234,
+      spanCount: 12,
+      rootStatusCode: 'Error',
+      serviceName: 'svc-a'
+    })])
+    expect(out.trim()).toBe('- aabbccddeeff0011…  GET /things  [error 1.23s 12 spans]  service=svc-a')
+  })
+
+  it('returns an empty string for an empty list', () => {
+    expect(buildTracesSummaryList([])).toBe('')
+  })
+
+  it('omits the service tail when the trace has no service.name', () => {
+    const out = buildTracesSummaryList([traceSummary({ serviceName: null })])
+    expect(out.trim()).not.toContain('service=')
   })
 })


### PR DESCRIPTION
## Summary
- Adds a single split-button in the toolbar of the **Logs**, **Traces**, and **Trace detail** pages that exports the current view in multiple formats. Primary click is OTLP/JSON; the caret dropdown exposes the alternative formats.
- Supported formats:
  - **OTLP/JSON** — the official envelope, re-importable by any OTLP-aware tool.
  - **logfmt (.log)** for logs and **tree text (.txt)** for traces — human/grep-friendly.
  - **CSV (.csv)** — mirrors what the table grid is showing.
  - **Copy to clipboard** — a Markdown block with a context header (window, filters, count) intended to be pasted into an LLM chat.
- Export captures "what I'm looking at right now": same filters/window the page already applies, no extra round-trip for logs and the table-CSV path. For trace lists, span detail is fanned out with a bounded concurrency (6) and failures on individual traces are skipped rather than aborting the whole export.

## Implementation notes
- New shared library code under `web/app/lib/`:
  - `otlpExport.ts` — builds OTLP/JSON envelopes for logs and spans and triggers the download.
  - `textExport.ts` — logfmt / tree / CSV serializers, clipboard helper, and the Markdown wrapper used for the "copy to LLM" flow.
- New `SplitActionDescriptor` (`web/app/types/toolbar.ts`) and rendering branch in `AppToolbar.vue` so any page can declare a split button via the existing toolbar contract. Loading/disabled apply to the whole control to prevent re-entrancy while a trace export is in flight.
- i18n keys added under `logs.export.*`, `traces.export.*`, `traces.detail.export.*`, plus `common.copyFailed` / `common.moreOptions`, for both `en` and `it` locales.