### PR TITLE
fix(dashboard): emit valid widget IDs on non-secure (HTTP/IIS) origins

### DIFF
--- a/web/app/demo/state/DashboardStore.ts
+++ b/web/app/demo/state/DashboardStore.ts
@@ -2,6 +2,7 @@ import type {
   DashboardDto,
   SaveDashboardRequest
 } from '~/services/types'
+import { newGuid } from '~/lib/uuid'
 import type { StorageService } from '../storage/StorageService'
 import { SEED_DASHBOARDS } from '../data/dashboards'
 
@@ -35,7 +36,7 @@ export class DashboardStore {
 
   create(req: SaveDashboardRequest): DashboardDto {
     const next: DashboardDto = {
-      id: randomUuid(),
+      id: newGuid(),
       name: req.name,
       widgets: req.widgets,
       updatedAt: new Date().toISOString(),
@@ -78,16 +79,6 @@ export class DashboardStore {
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T
-}
-
-function randomUuid(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID()
-  }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0
-    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
-  })
 }
 
 function notFound(message: string): Error {

--- a/web/app/demo/state/WidgetDefinitionStore.ts
+++ b/web/app/demo/state/WidgetDefinitionStore.ts
@@ -2,6 +2,7 @@ import type {
   SaveWidgetDefinitionRequest,
   WidgetDefinitionDto
 } from '~/services/types'
+import { newGuid } from '~/lib/uuid'
 import type { StorageService } from '../storage/StorageService'
 import { demoError } from './DashboardStore'
 
@@ -32,7 +33,7 @@ export class WidgetDefinitionStore {
 
   create(req: SaveWidgetDefinitionRequest): WidgetDefinitionDto {
     const next: WidgetDefinitionDto = {
-      id: randomUuid(),
+      id: newGuid(),
       name: req.name,
       description: req.description,
       icon: req.icon,
@@ -82,14 +83,4 @@ export class WidgetDefinitionStore {
     if (!list.some((w) => w.id === id)) throw demoError(404, `Widget definition ${id} not found`)
     this.storage.set(KEY, list.filter((w) => w.id !== id))
   }
-}
-
-function randomUuid(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID()
-  }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0
-    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
-  })
 }

--- a/web/app/lib/uuid.ts
+++ b/web/app/lib/uuid.ts
@@ -1,0 +1,31 @@
+/**
+ * Mints a fresh v4 GUID. Backend columns are `uniqueidentifier` and the
+ * deserializer rejects anything that isn't a real GUID, so this function
+ * must always return a parseable one.
+ *
+ * `crypto.randomUUID` is the natural choice, but it's gated by the browser's
+ * secure-context rules — it's only defined on HTTPS, `localhost`, and `file://`
+ * origins. A production deploy on plain HTTP (e.g. IIS over an intranet
+ * hostname) leaves it `undefined`, even though the `crypto` object itself is
+ * still present. `crypto.getRandomValues`, on the other hand, is available in
+ * every context, so we use it to build a conformant v4 UUID when the
+ * convenience API is missing. The pure-`Math.random` branch is only there for
+ * truly exotic environments without Web Crypto at all.
+ */
+export function newGuid(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const b = new Uint8Array(16)
+    crypto.getRandomValues(b)
+    b[6] = (b[6]! & 0x0f) | 0x40
+    b[8] = (b[8]! & 0x3f) | 0x80
+    const h = Array.from(b, x => x.toString(16).padStart(2, '0')).join('')
+    return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0
+    return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
+  })
+}

--- a/web/app/pages/dashboard/composables/useDashboardEdit.ts
+++ b/web/app/pages/dashboard/composables/useDashboardEdit.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types'
 import { normalizeKind } from '../types'
 import { defaultConfigForDefinition, useWidgetCatalog } from '../catalog'
+import { newGuid } from '~/lib/uuid'
 
 /**
  * Edit-mode state machine. Holds the mutable working copy of the layout, a
@@ -72,13 +73,6 @@ export function useDashboardEdit() {
     editingWidgetId.value = null
   }
 
-  function nextWidgetId(): string {
-    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
-      return crypto.randomUUID()
-    }
-    return `w-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  }
-
   /** Where to drop a new widget so it doesn't overlap the current layout. */
   function nextRowFor(_width: number): { x: number; y: number } {
     const widgets = layout.value.widgets
@@ -107,7 +101,7 @@ export function useDashboardEdit() {
     const size = def.defaultSize
     const pos = nextRowFor(size.w)
     const item: WidgetItem = {
-      id: nextWidgetId(),
+      id: newGuid(),
       kind: fq,
       x: pos.x,
       y: pos.y,

--- a/web/app/pages/dashboard/dashboardLayoutIO.ts
+++ b/web/app/pages/dashboard/dashboardLayoutIO.ts
@@ -1,5 +1,6 @@
 import type { MetricsService } from '~/services/MetricsService'
 import type { InstrumentDto } from '~/services/types'
+import { newGuid } from '~/lib/uuid'
 import type {
   DashboardLayout,
   MetricBinding,
@@ -144,19 +145,8 @@ function todayStamp(): string {
 // also be unique *within* the import: `grid-layout-plus` keys items by id,
 // so duplicates collapse into a single grid cell and the rest lose their
 // coordinates.
-const EMPTY_GUID = '00000000-0000-0000-0000-000000000000'
-
-function newWidgetId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID()
-  }
-  // No secure-context UUID available: let the server assign one. The grid
-  // will briefly collapse duplicates until the save round-trips fresh ids.
-  return EMPTY_GUID
-}
-
 function normalizeWidgetId(widget: WidgetItem): WidgetItem {
-  return { ...widget, id: newWidgetId() }
+  return { ...widget, id: newGuid() }
 }
 
 // --- validation ---


### PR DESCRIPTION
root cause (crypto.randomUUID solo in secure context), fix (centralizzazione + getRandomValues per v4 in HTTP)
Closes #2