### PR TITLE
fix(traces,logs): persist rolling time preset in URL so Live Mode recomputes from now after back-nav

### DIFF
--- a/web/app/components/form/AppDateTimeRangePicker.vue
+++ b/web/app/components/form/AppDateTimeRangePicker.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import type { TimeWindow } from '~/services/types'
+import {
+  TIME_RANGE_PRESET_MINUTES,
+  isKnownPresetKey,
+  presetToWindow
+} from '~/lib/timeRangePresets'
 
 interface Preset {
   key: string
@@ -8,16 +13,24 @@ interface Preset {
 }
 
 const presets: Preset[] = [
-  { key: '5m', labelKey: 'filter.range5m', minutes: 5 },
-  { key: '15m', labelKey: 'filter.range15m', minutes: 15 },
-  { key: '1h', labelKey: 'filter.range1h', minutes: 60 },
-  { key: '6h', labelKey: 'filter.range6h', minutes: 60 * 6 },
-  { key: '24h', labelKey: 'filter.range24h', minutes: 60 * 24 },
-  { key: '7d', labelKey: 'filter.range7d', minutes: 60 * 24 * 7 }
+  { key: '5m', labelKey: 'filter.range5m', minutes: TIME_RANGE_PRESET_MINUTES['5m']! },
+  { key: '15m', labelKey: 'filter.range15m', minutes: TIME_RANGE_PRESET_MINUTES['15m']! },
+  { key: '1h', labelKey: 'filter.range1h', minutes: TIME_RANGE_PRESET_MINUTES['1h']! },
+  { key: '6h', labelKey: 'filter.range6h', minutes: TIME_RANGE_PRESET_MINUTES['6h']! },
+  { key: '24h', labelKey: 'filter.range24h', minutes: TIME_RANGE_PRESET_MINUTES['24h']! },
+  { key: '7d', labelKey: 'filter.range7d', minutes: TIME_RANGE_PRESET_MINUTES['7d']! }
 ]
 
 const props = defineProps<{
   modelValue: TimeWindow
+  /** Active rolling preset, when one is in effect. When set, the picker
+   *  highlights the matching button and displays its label as the summary
+   *  — independent of where `modelValue` happens to sit (it may drift
+   *  forward of "now" because the parent recomputed for a live tick).
+   *  `null` means "custom window" (or unknown to this picker). Callers
+   *  that don't pass the prop fall back to the legacy heuristic that
+   *  infers a preset from `modelValue` only when `to ≈ now`. */
+  preset?: string | null
   disabled?: boolean
   /** Server retention for the kind of data this picker filters. When set
    *  and > 0, the popover renders an info icon top-right with a tooltip
@@ -32,7 +45,14 @@ const props = defineProps<{
   maxWindowHours?: number | null
 }>()
 
-const emit = defineEmits<{ 'update:modelValue': [value: TimeWindow] }>()
+const emit = defineEmits<{
+  'update:modelValue': [value: TimeWindow]
+  /** Emitted alongside `update:modelValue`. A preset key (e.g. `'1h'`)
+   *  when the user clicked a quick-pick, `null` when they applied a
+   *  custom from/to. Pages persist this in the URL as `?range=1h` so
+   *  the rolling semantic survives back-navigation. */
+  'update:preset': [value: string | null]
+}>()
 
 const { t, locale } = useI18n()
 const isOpen = ref(false)
@@ -57,14 +77,14 @@ function syncDrafts() {
 watch(() => [props.modelValue.from, props.modelValue.to], syncDrafts, { immediate: true })
 
 function applyPreset(p: Preset) {
-  const to = new Date()
-  const from = new Date(to.getTime() - p.minutes * 60_000)
-  emit('update:modelValue', { from: from.toISOString(), to: to.toISOString() })
+  emit('update:preset', p.key)
+  emit('update:modelValue', presetToWindow(p.key as keyof typeof TIME_RANGE_PRESET_MINUTES))
   isOpen.value = false
 }
 
 function applyDrafts() {
   if (!draftFrom.value || !draftTo.value) return
+  emit('update:preset', null)
   emit('update:modelValue', {
     from: localInputToIso(draftFrom.value),
     to: localInputToIso(draftTo.value)
@@ -72,7 +92,16 @@ function applyDrafts() {
   isOpen.value = false
 }
 
+// When the parent passes `preset`, trust it and skip the from/to-based
+// inference (the parent's recomputed window may drift forward of "now"
+// between live ticks, breaking the `closeToNow` heuristic).
 const matchedPreset = computed<Preset | null>(() => {
+  if (isKnownPresetKey(props.preset)) {
+    return presets.find(p => p.key === props.preset) ?? null
+  }
+  if (props.preset === null) return null
+  // Legacy path for callers that haven't wired `preset` yet
+  // (service-map, metrics): infer when `to ≈ now` and span matches.
   const from = new Date(props.modelValue.from).getTime()
   const to = new Date(props.modelValue.to).getTime()
   const span = to - from

--- a/web/app/components/shell/AppToolbar.vue
+++ b/web/app/components/shell/AppToolbar.vue
@@ -150,10 +150,12 @@ const { t } = useI18n()
         <AppDateTimeRangePicker
           v-else-if="f.kind === 'time-range'"
           :model-value="f.modelValue.value"
+          :preset="f.preset?.value ?? null"
           :disabled="f.disabled?.value"
           :retention-days="f.retentionDays?.value ?? null"
           :max-window-hours="f.maxWindowHours?.value ?? null"
           @update:model-value="f.modelValue.value = $event"
+          @update:preset="(v: string | null) => { if (f.preset) f.preset.value = v }"
         />
         <AppLimitSelect
           v-else-if="f.kind === 'limit'"

--- a/web/app/lib/timeRangePresets.ts
+++ b/web/app/lib/timeRangePresets.ts
@@ -1,0 +1,36 @@
+import type { TimeWindow } from '~/services/types'
+
+/**
+ * Time-range preset table shared by the date-time picker and the page
+ * composables. Keys are URL-stable (`?range=1h`) — never rename without
+ * a redirect.
+ *
+ * The picker treats these as "rolling" anchors at `now`. Composables
+ * use {@link presetToWindow} to recompute the absolute window on
+ * hydration and (in live mode) on each tick, so the trailing edge
+ * doesn't drift after navigation away and back.
+ */
+export const TIME_RANGE_PRESET_MINUTES: Record<string, number> = {
+  '5m': 5,
+  '15m': 15,
+  '1h': 60,
+  '6h': 60 * 6,
+  '24h': 60 * 24,
+  '7d': 60 * 24 * 7
+}
+
+export type TimeRangePresetKey = keyof typeof TIME_RANGE_PRESET_MINUTES
+
+export function isKnownPresetKey(value: unknown): value is TimeRangePresetKey {
+  return typeof value === 'string' && value in TIME_RANGE_PRESET_MINUTES
+}
+
+export function presetToWindow(preset: TimeRangePresetKey, now: number = Date.now()): TimeWindow {
+  // Non-null assertion is justified by the `TimeRangePresetKey` type — every
+  // declared key has an entry in the table. `noUncheckedIndexedAccess` makes
+  // TS flag the lookup as possibly-undefined anyway.
+  const minutes = TIME_RANGE_PRESET_MINUTES[preset]!
+  const to = new Date(now)
+  const from = new Date(now - minutes * 60_000)
+  return { from: from.toISOString(), to: to.toISOString() }
+}

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -51,6 +51,10 @@ function numFromQuery(key: string): number | undefined {
   const n = Number(s)
   return Number.isFinite(n) && n > 0 ? n : undefined
 }
+// `?range=1h` takes precedence over `from`/`to` when present: the URL
+// is encoding a rolling-window intent, and the composable will
+// recompute the absolute window from `now` on hydration.
+const presetQ = strFromQuery('range')
 const fromQ = strFromQuery('from')
 const toQ = strFromQuery('to')
 const initialRange: TimeWindow | undefined = fromQ && toQ ? { from: fromQ, to: toQ } : undefined
@@ -70,6 +74,7 @@ if (legacyService) initialServices.push(legacyService)
 const page = useLogsPage($logsService, {
   initialTraceId: strFromQuery('traceId'),
   initialRange,
+  initialPreset: presetQ,
   initialServices,
   initialSeverity,
   initialBody: strFromQuery('bodyContains'),
@@ -127,7 +132,7 @@ const filters: FilterDescriptor[] = [
   // Application stays interactive in live mode: changing it triggers a reload
   // (watcher inside useLogsPage) and the next live tick uses the new filter.
   { kind: 'application', modelValue: page.service, options: page.availableServices },
-  { kind: 'time-range', modelValue: page.range, disabled: page.isLive, retentionDays: $logRetentionDays, maxWindowHours: $queryMaxWindowHours },
+  { kind: 'time-range', modelValue: page.range, preset: page.rangePreset, disabled: page.isLive, retentionDays: $logRetentionDays, maxWindowHours: $queryMaxWindowHours },
   { kind: 'severity', modelValue: page.severityFilter },
   { kind: 'attributes', modelValue: page.attributeFilters },
   { kind: 'limit', modelValue: page.limit, disabled: page.isLive }

--- a/web/app/pages/logs/usePage.ts
+++ b/web/app/pages/logs/usePage.ts
@@ -3,9 +3,16 @@ import { useLivePolling } from '~/composables/useLivePolling'
 import type { LogsService } from '~/services/LogsService'
 import type { LogRecordDto, TimeWindow } from '~/services/types'
 import type { SeverityBucket } from '~/types/filters'
+import { isKnownPresetKey, presetToWindow } from '~/lib/timeRangePresets'
 
 export interface UseLogsPageOptions {
   initialRange?: TimeWindow
+  /** Rolling preset key (e.g. `'1h'`). When set, the window is
+   *  recomputed relative to `now` on hydration — so back-navigation
+   *  from a log detail returns to "now - 1h" rather than the frozen
+   *  pair of timestamps the URL might still carry. `initialRange` is
+   *  ignored in that case. */
+  initialPreset?: string | null
   initialTraceId?: string
   initialServices?: string[]
   initialSeverity?: SeverityBucket[]
@@ -43,7 +50,24 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
     return { from: from.toISOString(), to: to.toISOString() }
   }
 
-  const range = ref<TimeWindow>(options.initialRange ?? defaultWindow())
+  // Three hydration branches:
+  //  1. URL has a known `?range=` → rolling preset wins, even if stale
+  //     `?from=&to=` is also present (that's exactly how back-nav gets
+  //     a fresh window).
+  //  2. URL has explicit `?from=&to=` → custom absolute window, no
+  //     preset; shareable as a static snapshot.
+  //  3. URL has neither → default to the rolling `1h` preset. Without
+  //     this branch a fresh visit would persist absolute timestamps and
+  //     back-nav from a log detail would land on a frozen window.
+  const rangePreset = ref<string | null>(
+    isKnownPresetKey(options.initialPreset)
+      ? options.initialPreset
+      : (options.initialRange ? null : '1h')
+  )
+  const initialWindow = rangePreset.value
+    ? presetToWindow(rangePreset.value)
+    : (options.initialRange ?? defaultWindow())
+  const range = ref<TimeWindow>(initialWindow)
   const traceId = ref<string | undefined>(options.initialTraceId)
   // Multi-value allow-list for `service.name`. Empty array is the
   // canonical "no filter" state — same convention used by the
@@ -192,10 +216,18 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
   // bookmarks land on the same view. Optional (defaulted) values are
   // omitted to keep the URL short — the parser on the receiving end
   // falls back to the same defaults.
+  //
+  // Rolling presets serialise as `range=1h` (no from/to) so a round-
+  // trip through `/logs/{id}` and back recomputes the window from
+  // `now` — without that, the absolute timestamps would freeze and
+  // Live Mode would resume from a stale window.
   const queryState = computed(() => {
-    const q: Record<string, string | string[]> = {
-      from: range.value.from,
-      to: range.value.to
+    const q: Record<string, string | string[]> = {}
+    if (rangePreset.value) {
+      q.range = rangePreset.value
+    } else {
+      q.from = range.value.from
+      q.to = range.value.to
     }
     if (traceId.value) q.traceId = traceId.value
     if (serviceFilter.value.length > 0) q.services = serviceFilter.value.join(',')
@@ -217,6 +249,7 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
 
   return {
     range,
+    rangePreset,
     limit,
     traceId,
     service: serviceFilter,

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -48,6 +48,10 @@ function numFromQuery(key: string): number | undefined {
   const n = Number(s)
   return Number.isFinite(n) && n > 0 ? n : undefined
 }
+// `?range=1h` takes precedence over `from`/`to` when present: the URL
+// is encoding a rolling-window intent, and the composable will
+// recompute the absolute window from `now` on hydration.
+const presetQ = strFromQuery('range')
 const fromQ = strFromQuery('from')
 const toQ = strFromQuery('to')
 const initialRange: TimeWindow | undefined = fromQ && toQ ? { from: fromQ, to: toQ } : undefined
@@ -69,6 +73,7 @@ if (legacyService) initialServices.push(legacyService)
 
 const page = useTracesPage($traceService, {
   initialRange,
+  initialPreset: presetQ,
   initialServices,
   initialNoService: strFromQuery('noService') === 'true',
   initialServiceMatch: strFromQuery('serviceMatch') === 'any' ? 'any' : 'root',
@@ -108,7 +113,7 @@ const filters: FilterDescriptor[] = [
   // Application stays interactive in live mode: changing it triggers a reload
   // (watcher inside useTracesPage) and the next live tick uses the new filter.
   { kind: 'application', modelValue: page.service, options: page.availableServices, matchMode: page.serviceMatch },
-  { kind: 'time-range', modelValue: page.range, disabled: page.isLive, retentionDays: $traceRetentionDays, maxWindowHours: $queryMaxWindowHours },
+  { kind: 'time-range', modelValue: page.range, preset: page.rangePreset, disabled: page.isLive, retentionDays: $traceRetentionDays, maxWindowHours: $queryMaxWindowHours },
   { kind: 'status', modelValue: page.statusFilter },
   { kind: 'duration', modelValue: page.durationFilter },
   { kind: 'attributes', modelValue: page.attributeFilters },

--- a/web/app/pages/traces/usePage.ts
+++ b/web/app/pages/traces/usePage.ts
@@ -3,6 +3,7 @@ import { useLivePolling } from '~/composables/useLivePolling'
 import type { TraceService } from '~/services/TraceService'
 import type { TimeWindow, TraceSummaryDto } from '~/services/types'
 import type { DurationRange, TraceStatusFilter } from '~/types/filters'
+import { isKnownPresetKey, presetToWindow } from '~/lib/timeRangePresets'
 
 const MAX_LIVE_ITEMS = 5000
 const LIVE_DELTA_LIMIT = 500
@@ -10,6 +11,12 @@ const DEFAULT_LIMIT = 50
 
 export interface UseTracesPageOptions {
   initialRange?: TimeWindow
+  /** Rolling preset key (e.g. `'1h'`). When set, the window is
+   *  recomputed relative to `now` on hydration — so back-navigation
+   *  from a trace detail returns to "now - 1h" rather than the frozen
+   *  pair of timestamps the URL might still carry. `initialRange` is
+   *  ignored in that case. */
+  initialPreset?: string | null
   initialServices?: string[]
   /** When true, restrict the listing to traces involving Resources
    *  with no `service.name` (null or empty). Drives the service-map's
@@ -40,7 +47,24 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
     return { from: from.toISOString(), to: to.toISOString() }
   }
 
-  const range = ref<TimeWindow>(options.initialRange ?? defaultWindow())
+  // Three hydration branches:
+  //  1. URL has a known `?range=` → rolling preset wins, even if stale
+  //     `?from=&to=` is also present (that's exactly how back-nav gets
+  //     a fresh window).
+  //  2. URL has explicit `?from=&to=` → custom absolute window, no
+  //     preset; shareable as a static snapshot.
+  //  3. URL has neither → default to the rolling `1h` preset. Without
+  //     this branch a fresh visit would persist absolute timestamps and
+  //     back-nav from a trace detail would land on a frozen window.
+  const rangePreset = ref<string | null>(
+    isKnownPresetKey(options.initialPreset)
+      ? options.initialPreset
+      : (options.initialRange ? null : '1h')
+  )
+  const initialWindow = rangePreset.value
+    ? presetToWindow(rangePreset.value)
+    : (options.initialRange ?? defaultWindow())
+  const range = ref<TimeWindow>(initialWindow)
   // Multi-value allow-list for `service.name`. Empty array means
   // "all applications" — the convention used by the picker and the
   // server-side `services=` URL param.
@@ -191,10 +215,18 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
 
   // Filter state encoded for URL persistence — see logs/usePage for
   // the rationale. Defaulted values are omitted to keep the URL short.
+  //
+  // Rolling presets serialise as `range=1h` (no from/to) so a round-
+  // trip through `/traces/{id}` and back recomputes the window from
+  // `now` — without that, the absolute timestamps would freeze and
+  // Live Mode would resume from a stale window.
   const queryState = computed(() => {
-    const q: Record<string, string | string[]> = {
-      from: range.value.from,
-      to: range.value.to
+    const q: Record<string, string | string[]> = {}
+    if (rangePreset.value) {
+      q.range = rangePreset.value
+    } else {
+      q.from = range.value.from
+      q.to = range.value.to
     }
     if (noServiceFilter.value) q.noService = 'true'
     else if (serviceFilter.value.length > 0) q.services = serviceFilter.value.join(',')
@@ -218,6 +250,7 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
 
   return {
     range,
+    rangePreset,
     limit,
     service: serviceFilter,
     noService: noServiceFilter,

--- a/web/app/types/toolbar.ts
+++ b/web/app/types/toolbar.ts
@@ -36,6 +36,14 @@ export interface ApplicationFilterDescriptor {
 export interface TimeRangeFilterDescriptor {
   kind: 'time-range'
   modelValue: Ref<TimeWindow>
+  /**
+   * Active rolling preset key (e.g. `'1h'`), or `null` for a custom
+   * window. Optional — pages that want their time filter to roll across
+   * back-navigation bind this so the URL can persist `?range=1h`
+   * instead of a frozen pair of timestamps. Omitted by pages where
+   * the time window is always absolute.
+   */
+  preset?: Ref<string | null>
   disabled?: Ref<boolean>
   /**
    * Server-configured retention window for the data this picker

--- a/web/tests/pages/useTracesPage.preset.spec.ts
+++ b/web/tests/pages/useTracesPage.preset.spec.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTracesPage } from '~/pages/traces/usePage'
+import type { HttpClientService } from '~/services/HttpClientService'
+import { TraceService } from '~/services/TraceService'
+import type { PagedResponse, TraceSummaryDto } from '~/services/types'
+
+function installDocumentStub() {
+  vi.stubGlobal('document', {
+    visibilityState: 'visible',
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  })
+}
+
+function stubHttp(pages: Array<PagedResponse<TraceSummaryDto>>) {
+  const tracesPages = [...pages]
+  const get = vi.fn(async (path: string) => {
+    if (path === '/v1/traces/services') return [] as string[]
+    return tracesPages.shift() ?? { items: [], nextCursor: null }
+  })
+  return {
+    client: {
+      get,
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn()
+    } as unknown as HttpClientService,
+    get
+  }
+}
+
+describe('useTracesPage — rolling preset hydration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    installDocumentStub()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('recomputes window from now when a known preset is supplied, ignoring stale initialRange', async () => {
+    // Pin the clock so the expected window is deterministic.
+    const fixedNow = new Date('2030-06-01T12:00:00.000Z')
+    vi.setSystemTime(fixedNow)
+
+    const http = stubHttp([{ items: [], nextCursor: null }])
+    const service = new TraceService(http.client)
+
+    // The "stale" absolute range mimics what the URL still carries
+    // from a router.replace that fired the last time the user was on
+    // the page — older than now, and definitely not what they want
+    // when they hit Back from a trace detail.
+    const stale = {
+      from: '2030-06-01T08:00:00.000Z',
+      to: '2030-06-01T09:00:00.000Z'
+    }
+
+    const page = useTracesPage(service, {
+      initialRange: stale,
+      initialPreset: '1h',
+      autoLive: false
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Window is recomputed: to=now, from=now-1h. The stale URL
+    // timestamps are ignored.
+    expect(page.range.value.to).toBe('2030-06-01T12:00:00.000Z')
+    expect(page.range.value.from).toBe('2030-06-01T11:00:00.000Z')
+    expect(page.rangePreset.value).toBe('1h')
+
+    // queryState round-trips as `?range=1h` (no from/to leaks).
+    expect(page.queryState.value).toMatchObject({ range: '1h' })
+    expect(page.queryState.value.from).toBeUndefined()
+    expect(page.queryState.value.to).toBeUndefined()
+
+    // The initial /v1/traces fetch used the recomputed window, not
+    // the stale URL timestamps.
+    const tracesCalls = http.get.mock.calls.filter(c => c[0] === '/v1/traces')
+    expect(tracesCalls[0]?.[1]).toMatchObject({
+      from: '2030-06-01T11:00:00.000Z',
+      to: '2030-06-01T12:00:00.000Z'
+    })
+  })
+
+  it('defaults to the rolling 1h preset when neither preset nor range is in the URL', async () => {
+    vi.setSystemTime(new Date('2030-06-01T12:00:00.000Z'))
+    const http = stubHttp([{ items: [], nextCursor: null }])
+    const service = new TraceService(http.client)
+
+    const page = useTracesPage(service, { autoLive: false })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // Default is the rolling preset, not an absolute window — otherwise
+    // a fresh visit's URL would freeze the timestamps and back-nav from
+    // a trace detail would land on a stale window.
+    expect(page.rangePreset.value).toBe('1h')
+    expect(page.queryState.value).toMatchObject({ range: '1h' })
+    expect(page.queryState.value.from).toBeUndefined()
+    expect(page.queryState.value.to).toBeUndefined()
+  })
+
+  it('falls back to initialRange when the preset is unknown', async () => {
+    vi.setSystemTime(new Date('2030-06-01T12:00:00.000Z'))
+    const http = stubHttp([{ items: [], nextCursor: null }])
+    const service = new TraceService(http.client)
+
+    const explicit = {
+      from: '2030-06-01T08:00:00.000Z',
+      to: '2030-06-01T09:00:00.000Z'
+    }
+    const page = useTracesPage(service, {
+      initialRange: explicit,
+      initialPreset: 'not-a-preset',
+      autoLive: false
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(page.rangePreset.value).toBeNull()
+    expect(page.range.value).toEqual(explicit)
+    expect(page.queryState.value).toMatchObject({
+      from: explicit.from,
+      to: explicit.to
+    })
+    expect(page.queryState.value.range).toBeUndefined()
+  })
+})


### PR DESCRIPTION
- Closes #6. The traces and logs filters now persist the rolling time preset as `?range=1h` instead of freezing absolute `?from=&to=`, so navigating into a trace/log detail and pressing Back recomputes the window relative to "now" — Live Mode catches up instead of resuming from the snapshot.
- Default hydration: when neither `?range=` nor `?from=&to=` is in the URL, the composable seeds `rangePreset = '1h'` so a fresh visit also rolls — without that, the very first round-trip through a detail page would still freeze the window.
- Custom ranges (Apply-with-explicit-dates in the picker) still serialise as `?from=&to=` and behave as shareable absolute snapshots.