### PR TITLE
feat(web): respect system 12h/24h preference via centralized dateTimeFormat helper (#8)

### DIFF
--- a/web/app/components/form/AppDateTimeRangePicker.vue
+++ b/web/app/components/form/AppDateTimeRangePicker.vue
@@ -5,6 +5,7 @@ import {
   isKnownPresetKey,
   presetToWindow
 } from '~/lib/timeRangePresets'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 interface Preset {
   key: string
@@ -114,16 +115,9 @@ const matchedPreset = computed<Preset | null>(() => {
   return null
 })
 
-const formatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  dateStyle: 'short',
-  timeStyle: 'short'
-}))
-
 const summary = computed(() => {
   if (matchedPreset.value) return t(matchedPreset.value.labelKey)
-  const f = new Date(props.modelValue.from)
-  const ttt = new Date(props.modelValue.to)
-  return `${formatter.value.format(f)} → ${formatter.value.format(ttt)}`
+  return `${dateTimeFormat(props.modelValue.from, 'datetime', locale.value)} → ${dateTimeFormat(props.modelValue.to, 'datetime', locale.value)}`
 })
 
 // Two-line info-icon tooltip (retention + max-query-window). Each line

--- a/web/app/lib/agcharts/chartStrategy.ts
+++ b/web/app/lib/agcharts/chartStrategy.ts
@@ -8,6 +8,7 @@ import type { InstrumentDto, MetricSeriesDto } from '~/services/types'
 import { describeGroup, groupPoints, type SplitBy, type SeriesGroup } from './seriesGrouping'
 import { instrumentKey } from '~/pages/metrics/buildTree'
 import { escapeHtml } from '~/lib/escapeHtml'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 export type ChartType = 'line' | 'area' | 'column' | 'unsupported'
 
@@ -109,15 +110,9 @@ export function buildChartOptions(input: BuildOptionsInput): AgChartOptions {
       const name = prefix
         ? `${prefix}${describeGroup(g.attrs)}`
         : describeGroup(g.attrs)
-      allSeries.push(buildSeries(seriesType, name, data, yKey, formatValueFn))
+      allSeries.push(buildSeries(seriesType, name, data, yKey, formatValueFn, locale))
     }
   }
-
-  const fmt = new Intl.DateTimeFormat(locale, {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
 
   const xAxis: AgCartesianAxisOptions = compact
     ? {
@@ -132,7 +127,7 @@ export function buildChartOptions(input: BuildOptionsInput): AgChartOptions {
     : {
         type: 'time',
         position: 'bottom',
-        label: { format: '%H:%M:%S', formatter: ({ value }) => fmt.format(value as Date) },
+        label: { format: '%H:%M:%S', formatter: ({ value }) => dateTimeFormat(value as Date, 'time-seconds', locale) },
         nice: true
       }
 
@@ -206,9 +201,10 @@ function buildSeries(
   name: string,
   data: ChartDatum[],
   yKey: string,
-  formatValueFn: (v: number) => string
+  formatValueFn: (v: number) => string,
+  locale: string
 ): AgCartesianSeriesOptions {
-  const tooltip = { renderer: (params: TooltipParams) => tooltipRenderer(params, formatValueFn) }
+  const tooltip = { renderer: (params: TooltipParams) => tooltipRenderer(params, formatValueFn, locale) }
   if (type === 'line') {
     return { type: 'line', xKey: 'time', yKey, yName: name, data, marker: { enabled: false }, tooltip }
   }
@@ -301,14 +297,12 @@ interface TooltipParams {
 
 function tooltipRenderer(
   params: TooltipParams,
-  format: (v: number) => string
+  format: (v: number) => string,
+  locale: string
 ): { title?: string; content: string } {
   const { datum, yName, yValue } = params
   const value = typeof yValue === 'number' ? yValue : (datum[params.yKey] ?? 0)
-  const time = new Date(datum.time)
-  const timeLabel = time.toLocaleTimeString([], {
-    hour: '2-digit', minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3
-  } as Intl.DateTimeFormatOptions)
+  const timeLabel = dateTimeFormat(datum.time, 'time-ms', locale)
   const lines: string[] = [`<b>${escapeHtml(format(value as number))}</b> at ${escapeHtml(timeLabel)}`]
   if (datum.count !== undefined) lines.push(`count: ${formatNumber(datum.count)}`)
   if (datum.sum !== undefined) lines.push(`sum: ${format(datum.sum)}`)

--- a/web/app/lib/dateTimeFormat.ts
+++ b/web/app/lib/dateTimeFormat.ts
@@ -1,0 +1,76 @@
+/**
+ * Single entry point for every date/time string the UI renders.
+ *
+ * Why this lives in one place: previously every component built its own
+ * `Intl.DateTimeFormat` and inherited the i18n locale's hour cycle, so
+ * en-US users always saw AM/PM even when their OS was set to 24h. This
+ * module overrides `hour12` based on the *system* preference (resolved
+ * once via the user agent's default locale) so the active i18n locale
+ * still drives month names, date order and separators, but the clock
+ * cycle matches the OS.
+ */
+
+export type DateTimePreset =
+  /** Short date + short time — e.g. `5/30/26, 12:34`. Toolbar subtitles, picker summary. */
+  | 'datetime'
+  /** Short date + time with seconds — e.g. `5/30/26, 12:34:56`. Live windows. */
+  | 'datetime-seconds'
+  /** Medium date + medium time — e.g. `May 30, 2026, 12:34:56`. Detail panels. */
+  | 'datetime-long'
+  /** `12:34` — heatmap buckets. */
+  | 'time'
+  /** `12:34:56` — chart axes, stream rows, histogram tooltips. */
+  | 'time-seconds'
+  /** `12:34:56.123` — high-precision tooltips (spans, metric points). */
+  | 'time-ms'
+
+const PRESET_OPTIONS: Record<DateTimePreset, Intl.DateTimeFormatOptions> = {
+  'datetime':         { dateStyle: 'short',  timeStyle: 'short'  },
+  'datetime-seconds': { dateStyle: 'short',  timeStyle: 'medium' },
+  'datetime-long':    { dateStyle: 'medium', timeStyle: 'medium' },
+  'time':             { hour: '2-digit', minute: '2-digit' },
+  'time-seconds':     { hour: '2-digit', minute: '2-digit', second: '2-digit' },
+  'time-ms':          { hour: '2-digit', minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3 }
+}
+
+// `resolvedOptions().hour12` on the user agent's default locale reflects
+// that locale's standard hour cycle, which browsers derive from OS region
+// settings on Windows/macOS/Linux. Cached because the OS preference can't
+// change without a page reload.
+let cachedSystemHour12: boolean | null = null
+function systemHour12(): boolean {
+  if (cachedSystemHour12 === null) {
+    cachedSystemHour12 = new Intl.DateTimeFormat(undefined, { hour: 'numeric' })
+      .resolvedOptions().hour12 ?? false
+  }
+  return cachedSystemHour12
+}
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>()
+function getFormatter(locale: string | undefined, preset: DateTimePreset): Intl.DateTimeFormat {
+  const key = `${locale ?? ''}|${preset}`
+  let fmt = formatterCache.get(key)
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(locale, {
+      ...PRESET_OPTIONS[preset],
+      hour12: systemHour12()
+    })
+    formatterCache.set(key, fmt)
+  }
+  return fmt
+}
+
+/**
+ * Format a date/time value using a named preset, honoring the OS 12h/24h
+ * preference. `locale` controls everything else (month names, ordering,
+ * separators); when omitted, the formatter falls back to the user agent
+ * default.
+ */
+export function dateTimeFormat(
+  value: Date | number | string,
+  preset: DateTimePreset = 'datetime',
+  locale?: string
+): string {
+  const d = value instanceof Date ? value : new Date(value)
+  return getFormatter(locale, preset).format(d)
+}

--- a/web/app/pages/dashboard/index.vue
+++ b/web/app/pages/dashboard/index.vue
@@ -12,6 +12,7 @@ import WidgetConfigDrawer from './components/WidgetConfigDrawer.vue'
 import WidgetPickerDialog from './components/WidgetPickerDialog.vue'
 import { useDashboardPage } from './usePage'
 import type { ActionDescriptor } from '~/types/toolbar'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const { t, locale } = useI18n()
 const { $dashboardService, $metricsService } = useNuxtApp()
@@ -95,7 +96,7 @@ const subtitle = computed(() => {
   if (page.isEditing.value) return t('dashboard.subtitle.editing')
   const updatedRaw = page.dashboard.value?.updatedAt
   const updatedLabel = updatedRaw
-    ? new Intl.DateTimeFormat(locale.value, { dateStyle: 'short', timeStyle: 'short' }).format(new Date(updatedRaw))
+    ? dateTimeFormat(updatedRaw, 'datetime', locale.value)
     : '·'
   return t('dashboard.subtitle.view', {
     count: page.layout.value.widgets.length,

--- a/web/app/pages/dashboard/widgets/LogsStreamWidget.vue
+++ b/web/app/pages/dashboard/widgets/LogsStreamWidget.vue
@@ -4,6 +4,7 @@ import type { LogSeverityFilter, LogsStreamConfig } from '../types'
 import { WIDGET_REGISTRY } from '../registry'
 import { presetToWindow } from '../useWidgetSeries'
 import type { LogRecordDto } from '~/services/types'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = withDefaults(defineProps<{
   config: LogsStreamConfig
@@ -100,11 +101,7 @@ function severityLabel(l: LogRecordDto): string {
 }
 
 function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString(locale.value, {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return dateTimeFormat(iso, 'time-seconds', locale.value)
 }
 
 function bodyText(l: LogRecordDto): string {

--- a/web/app/pages/dashboard/widgets/MetricHeatmapWidget.vue
+++ b/web/app/pages/dashboard/widgets/MetricHeatmapWidget.vue
@@ -11,6 +11,7 @@ import { reduce, type CalcMode } from '~/lib/units/calc'
 import { formatValue, type UnitKind } from '~/lib/units/format'
 import { pickThreshold } from '~/lib/units/thresholds'
 import { describeGroup, groupPoints } from '~/lib/agcharts/seriesGrouping'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = withDefaults(defineProps<{
   config: MetricHeatmapConfig
@@ -145,7 +146,7 @@ function gradientColor(t: number, dark: boolean): string {
 }
 
 function formatBucketTime(ms: number): string {
-  return new Date(ms).toLocaleTimeString(locale.value, { hour: '2-digit', minute: '2-digit' })
+  return dateTimeFormat(ms, 'time', locale.value)
 }
 
 function tooltipFor(rowLabel: string, c: Cell, bucketMs: number): string {

--- a/web/app/pages/dashboard/widgets/MetricSparklineWidget.vue
+++ b/web/app/pages/dashboard/widgets/MetricSparklineWidget.vue
@@ -10,6 +10,7 @@ import type { MetricSparklineConfig } from '../types'
 import { WIDGET_REGISTRY } from '../registry'
 import { formatValue, type UnitKind } from '~/lib/units/format'
 import { escapeHtml } from '~/lib/escapeHtml'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = withDefaults(defineProps<{
   config: MetricSparklineConfig
@@ -53,12 +54,7 @@ interface SparkParams {
 }
 function tooltipRenderer(params: SparkParams): { title?: string; content: string } {
   const v = typeof params.yValue === 'number' ? params.yValue : Number(params.datum.value)
-  const time = params.datum.time
-  const timeLabel = time.toLocaleTimeString(locale.value, {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  const timeLabel = dateTimeFormat(params.datum.time, 'time-seconds', locale.value)
   const formatted = formatValue(v, unitKind.value, { decimals: decimals.value, locale: locale.value })
   return { content: `<b>${escapeHtml(formatted)}</b><br/>${escapeHtml(timeLabel)}` }
 }

--- a/web/app/pages/dashboard/widgets/RecentTracesWidget.vue
+++ b/web/app/pages/dashboard/widgets/RecentTracesWidget.vue
@@ -4,6 +4,7 @@ import type { RecentTracesConfig, TraceSortMode } from '../types'
 import { WIDGET_REGISTRY } from '../registry'
 import { presetToWindow } from '../useWidgetSeries'
 import type { TraceSummaryDto } from '~/services/types'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = withDefaults(defineProps<{
   config: RecentTracesConfig
@@ -84,12 +85,7 @@ const sorted = computed(() => {
 })
 
 function formatTime(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleTimeString(locale.value, {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return dateTimeFormat(iso, 'time-seconds', locale.value)
 }
 
 function formatDuration(ms: number): string {

--- a/web/app/pages/logs/components/LogDetailContent.vue
+++ b/web/app/pages/logs/components/LogDetailContent.vue
@@ -2,18 +2,14 @@
 import type { LogRecordDto } from '~/services/types'
 import { severityBucketFromNumber } from '~/types/filters'
 import AppBadge from '~/components/ui/AppBadge.vue'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = defineProps<{ record: LogRecordDto }>()
 
 const { t, locale } = useI18n()
 
-const formatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  dateStyle: 'medium',
-  timeStyle: 'medium'
-}))
-
 function fmt(iso: string | null): string {
-  return iso ? formatter.value.format(new Date(iso)) : '·'
+  return iso ? dateTimeFormat(iso, 'datetime-long', locale.value) : '·'
 }
 
 const bucket = computed(() => severityBucketFromNumber(props.record.severityNumber))

--- a/web/app/pages/logs/components/LogsSeverityHistogram.vue
+++ b/web/app/pages/logs/components/LogsSeverityHistogram.vue
@@ -13,6 +13,7 @@
  */
 import type { SeverityBucket } from '~/types/filters'
 import { STACK_ORDER, type SeverityHistogramData } from '../composables/useSeverityHistogram'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = defineProps<{
   data: SeverityHistogramData
@@ -63,11 +64,8 @@ interface RenderedColumn {
   title: string
 }
 
-const tooltipFormatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  hour: '2-digit', minute: '2-digit', second: '2-digit'
-}))
 function fmtTime(ms: number): string {
-  return tooltipFormatter.value.format(new Date(ms))
+  return dateTimeFormat(ms, 'time-seconds', locale.value)
 }
 
 const columns = computed<RenderedColumn[]>(() => {

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -25,6 +25,7 @@ import type {
 } from '~/types/toolbar'
 import type { LogRecordDto, TimeWindow } from '~/services/types'
 import { SEVERITY_BUCKETS, type SeverityBucket } from '~/types/filters'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -122,10 +123,7 @@ const subtitle = computed(() => {
 })
 
 function describeWindow(range: TimeWindow): string {
-  const f = new Date(range.from)
-  const tt = new Date(range.to)
-  const fmt = new Intl.DateTimeFormat(locale.value, { dateStyle: 'short', timeStyle: 'short' })
-  return `${fmt.format(f)} → ${fmt.format(tt)}`
+  return `${dateTimeFormat(range.from, 'datetime', locale.value)} → ${dateTimeFormat(range.to, 'datetime', locale.value)}`
 }
 
 const filters: FilterDescriptor[] = [

--- a/web/app/pages/metrics/components/MetricChartUnsupported.vue
+++ b/web/app/pages/metrics/components/MetricChartUnsupported.vue
@@ -2,6 +2,7 @@
 import type { ColDef } from 'ag-grid-community'
 import AppDataGrid from '~/components/data/AppDataGrid.vue'
 import type { MetricPointDto, MetricSeriesDto } from '~/services/types'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = defineProps<{
   series: MetricSeriesDto[]
@@ -9,13 +10,6 @@ const props = defineProps<{
 }>()
 
 const { t, locale } = useI18n()
-
-const formatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  fractionalSecondDigits: 3
-}))
 
 function formatValue(value: number): string {
   if (Number.isInteger(value)) return value.toString()
@@ -43,7 +37,7 @@ const columnDefs = computed<ColDef<Row>[]>(() => [
     width: 130,
     sort: 'desc',
     cellClass: 'font-mono text-xs items-center flex',
-    valueFormatter: p => p.value ? formatter.value.format(new Date(p.value as string)) : ''
+    valueFormatter: p => p.value ? dateTimeFormat(p.value as string, 'time-ms', locale.value) : ''
   },
   {
     field: 'instrumentName',

--- a/web/app/pages/metrics/index.vue
+++ b/web/app/pages/metrics/index.vue
@@ -8,6 +8,7 @@ import MetricChartPanel from './components/MetricChartPanel.vue'
 import { useMetricsPage } from './usePage'
 import type { ActionDescriptor, FilterDescriptor } from '~/types/toolbar'
 import type { TimeWindow, MetricSeriesDto } from '~/services/types'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const { t, locale } = useI18n()
 const { $metricsService, $metricRetentionDays, $queryMaxWindowHours } = useNuxtApp()
@@ -62,12 +63,9 @@ const subtitle = computed(() => t('metrics.subtitle', {
 }))
 
 function describeWindow(range: TimeWindow): string {
-  const f = new Date(range.from)
-  const tt = new Date(range.to)
-  // `medium` includes seconds, which matters in live mode where the window
-  // slides every second.
-  const fmt = new Intl.DateTimeFormat(locale.value, { dateStyle: 'short', timeStyle: 'medium' })
-  return `${fmt.format(f)} → ${fmt.format(tt)}`
+  // `datetime-seconds` keeps seconds in the label, which matters in live
+  // mode where the window slides every second.
+  return `${dateTimeFormat(range.from, 'datetime-seconds', locale.value)} → ${dateTimeFormat(range.to, 'datetime-seconds', locale.value)}`
 }
 
 const orderedSeries = computed<MetricSeriesDto[]>(() => {

--- a/web/app/pages/service-map.vue
+++ b/web/app/pages/service-map.vue
@@ -10,6 +10,7 @@ import { useIconResolver } from './serviceMap/composables/useIconResolver'
 import type { ResolvedServiceMapDto } from './serviceMap/composables/useForceLayout'
 import type { ActionDescriptor, FilterDescriptor } from '~/types/toolbar'
 import type { PackDto, ServiceMapDto, TimeWindow } from '~/services/types'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const { t, locale } = useI18n()
 const {
@@ -102,10 +103,7 @@ const subtitle = computed(() => {
 })
 
 function describeWindow(range: TimeWindow): string {
-  const f = new Date(range.from)
-  const tt = new Date(range.to)
-  const fmt = new Intl.DateTimeFormat(locale.value, { dateStyle: 'short', timeStyle: 'short' })
-  return `${fmt.format(f)} → ${fmt.format(tt)}`
+  return `${dateTimeFormat(range.from, 'datetime', locale.value)} → ${dateTimeFormat(range.to, 'datetime', locale.value)}`
 }
 
 // The map is exploratory, not a live monitor — refresh is manual.

--- a/web/app/pages/traces/[traceId].vue
+++ b/web/app/pages/traces/[traceId].vue
@@ -17,6 +17,7 @@ import {
   downloadText
 } from '~/lib/textExport'
 import type { ActionDescriptor, BreadcrumbItem } from '~/types/toolbar'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -42,12 +43,8 @@ const page = useTracePage($traceService, $logsService, traceId.value)
 type SpanView = 'tree' | 'flame'
 const spanView = ref<SpanView>('tree')
 
-const formatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  dateStyle: 'short',
-  timeStyle: 'medium'
-}))
 function fmtTime(iso: string): string {
-  return formatter.value.format(new Date(iso))
+  return dateTimeFormat(iso, 'datetime-seconds', locale.value)
 }
 function fmtDuration(ms: number): string {
   if (ms < 1) return `${(ms * 1000).toFixed(0)}μs`

--- a/web/app/pages/traces/components/SpanDetailPanel.vue
+++ b/web/app/pages/traces/components/SpanDetailPanel.vue
@@ -2,18 +2,14 @@
 import type { SpanDto } from '~/services/types'
 import AppBadge from '~/components/ui/AppBadge.vue'
 import AppEmptyState from '~/components/ui/AppEmptyState.vue'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = defineProps<{ span: SpanDto | null }>()
 
 const { t, locale } = useI18n()
 
-const formatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  dateStyle: 'medium',
-  timeStyle: 'medium'
-}))
-
 function fmtTime(iso: string): string {
-  return formatter.value.format(new Date(iso))
+  return dateTimeFormat(iso, 'datetime-long', locale.value)
 }
 
 function fmtDuration(ms: number): string {

--- a/web/app/pages/traces/components/SpanFlameGraph.vue
+++ b/web/app/pages/traces/components/SpanFlameGraph.vue
@@ -12,6 +12,7 @@
  */
 import type { LogRecordDto, SpanDto } from '~/services/types'
 import { type AlertBucket, buildTraceLayout } from '../composables/useTraceLayout'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = defineProps<{
   spans: SpanDto[]
@@ -53,11 +54,8 @@ function fmtDuration(ms: number): string {
   return `${(ms / 1000).toFixed(2)}s`
 }
 
-const tooltipFormatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  hour: '2-digit', minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3
-}))
 function fmtAlertTime(iso: string): string {
-  return tooltipFormatter.value.format(new Date(iso))
+  return dateTimeFormat(iso, 'time-ms', locale.value)
 }
 
 /** Convert a trace-relative position to a span-relative position so the

--- a/web/app/pages/traces/components/SpanTree.vue
+++ b/web/app/pages/traces/components/SpanTree.vue
@@ -2,6 +2,7 @@
 import type { LogRecordDto, SpanDto } from '~/services/types'
 import AppBadge from '~/components/ui/AppBadge.vue'
 import { type AlertBucket, buildTraceLayout } from '../composables/useTraceLayout'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const props = defineProps<{
   spans: SpanDto[]
@@ -15,11 +16,8 @@ const props = defineProps<{
 defineEmits<{ select: [span: SpanDto] }>()
 
 const { locale } = useI18n()
-const tooltipFormatter = computed(() => new Intl.DateTimeFormat(locale.value, {
-  hour: '2-digit', minute: '2-digit', second: '2-digit', fractionalSecondDigits: 3
-}))
 function fmtAlertTime(iso: string): string {
-  return tooltipFormatter.value.format(new Date(iso))
+  return dateTimeFormat(iso, 'time-ms', locale.value)
 }
 
 function alertIcon(bucket: AlertBucket): string {

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -23,6 +23,7 @@ import type {
 } from '~/types/toolbar'
 import type { TimeWindow, TraceSummaryDto } from '~/services/types'
 import type { TraceStatusFilter } from '~/types/filters'
+import { dateTimeFormat } from '~/lib/dateTimeFormat'
 
 const { t, locale } = useI18n()
 const route = useRoute()
@@ -103,10 +104,7 @@ const subtitle = computed(() => t('traces.subtitle', {
 }))
 
 function describeWindow(range: TimeWindow): string {
-  const f = new Date(range.from)
-  const tt = new Date(range.to)
-  const fmt = new Intl.DateTimeFormat(locale.value, { dateStyle: 'short', timeStyle: 'short' })
-  return `${fmt.format(f)} → ${fmt.format(tt)}`
+  return `${dateTimeFormat(range.from, 'datetime', locale.value)} → ${dateTimeFormat(range.to, 'datetime', locale.value)}`
 }
 
 const filters: FilterDescriptor[] = [


### PR DESCRIPTION
New `web/app/lib/dateTimeFormat.ts` exposes a single `dateTimeFormat(value, preset, locale?)` helper. It detects the user agent's default `hour12` once (via `Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions().hour12`, which browsers derive from OS region settings) and applies it to every formatter, so a user with system 24h no longer sees AM/PM just because the i18n locale defaults to 12h.