### PR TITLE
fix(traces,logs): allow deselect-all and quick single-app selection on the Applications filter

### DIFF
--- a/web/app/components/form/AppApplicationFilter.vue
+++ b/web/app/components/form/AppApplicationFilter.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
 /**
- * Multi-select picker over `service.name` values. Empty array is the
- * canonical "no filter" state — mirrors how the severity picker
- * encodes "all buckets" — so pages don't have to invent a sentinel.
+ * Multi-select picker over `service.name` values. Three pages of state:
+ *  - "all" → no filter applied (modelValue is empty AND noneSelected is false)
+ *  - "none" → user explicitly cleared every box (noneSelected is true)
+ *  - "subset" → modelValue is a non-empty allow-list
  *
- * The popover layout is intentionally identical to AppSeveritySelect
- * (pill button + checkbox list + leading "All" reset row) so the
- * toolbar reads as a coherent family of filters.
+ * The "none" state is distinct from "all" because users asked for the
+ * literal checkbox semantics: ticking "All applications" off should
+ * actually hide every row, not silently fall back to no-filter. The
+ * popover layout otherwise mirrors AppSeveritySelect so the toolbar
+ * reads as one family of filters.
  */
 const props = defineProps<{
   modelValue: string[]
   options: string[]
+  /** True when the user has explicitly deselected every application —
+   *  distinct from the implicit "all" state that empty `modelValue`
+   *  alone encodes. Pages that want the deselect-all affordance bind
+   *  this; pages that don't can omit it and the picker behaves as a
+   *  plain "all ↔ subset" toggle. */
+  noneSelected?: boolean
   /** Optional any-span / root match mode binding. When omitted the
    *  toggle row in the popover is hidden and the filter stays
    *  root-anchored — pages that don't surface the alternative don't
@@ -21,35 +30,68 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:modelValue': [value: string[]]
+  'update:noneSelected': [value: boolean]
   'update:matchMode': [value: 'root' | 'any']
 }>()
 
 const { t } = useI18n()
 const isOpen = ref(false)
 
-const allSelected = computed(() => props.modelValue.length === 0)
+const allSelected = computed(() => !props.noneSelected && props.modelValue.length === 0)
+const noneSelected = computed(() => props.noneSelected === true)
 
 function isChecked(name: string): boolean {
+  if (noneSelected.value) return false
   return allSelected.value || props.modelValue.includes(name)
 }
 
+function emitSelection(next: string[]) {
+  // Collapse the explicit full list back to the implicit "all" form so
+  // the URL stays compact, and clear the "none" flag whenever any
+  // positive selection is emitted.
+  if (props.noneSelected) emit('update:noneSelected', false)
+  if (next.length === props.options.length) emit('update:modelValue', [])
+  else emit('update:modelValue', next)
+}
+
 function toggle(name: string) {
-  // Implicit "all" → explicit "all-but-this" the moment the user
-  // de-selects an option. Re-toggling everything back to the full set
-  // collapses to the implicit form so the URL stays compact.
+  // Independent checkbox semantics: each click flips just that row,
+  // materialising from the implicit "all" state on first deselect and
+  // collapsing back when the explicit list re-covers every option.
+  // Toggling out of the "none" state starts a fresh single-item list.
+  if (noneSelected.value) {
+    emitSelection([name])
+    return
+  }
   const explicit = allSelected.value ? [...props.options] : [...props.modelValue]
   const idx = explicit.indexOf(name)
   if (idx >= 0) explicit.splice(idx, 1)
   else explicit.push(name)
-  if (explicit.length === props.options.length) emit('update:modelValue', [])
-  else emit('update:modelValue', explicit)
+  if (explicit.length === 0) {
+    // Last box just got unchecked from an explicit list — treat that as
+    // the literal "deselect all" the user asked for, not as no-filter.
+    emit('update:modelValue', [])
+    emit('update:noneSelected', true)
+    return
+  }
+  emitSelection(explicit)
 }
 
-function selectAll() {
-  emit('update:modelValue', [])
+function toggleAll() {
+  if (allSelected.value) {
+    // All → none: encodes the user's explicit "deselect all" intent.
+    emit('update:modelValue', [])
+    emit('update:noneSelected', true)
+  } else {
+    // Anything else (none / subset) → all: collapses to the compact
+    // implicit-all form and clears the none flag.
+    emit('update:modelValue', [])
+    if (props.noneSelected) emit('update:noneSelected', false)
+  }
 }
 
 const buttonLabel = computed(() => {
+  if (noneSelected.value) return t('filter.applicationNone')
   if (allSelected.value) return t('filter.applicationAll')
   if (props.modelValue.length === 1) return props.modelValue[0]!
   return t('filter.applicationCount', { count: props.modelValue.length })
@@ -83,7 +125,7 @@ function toggleMatchMode() {
         <button
           type="button"
           class="w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm hover:bg-elevated transition-colors"
-          @click="selectAll"
+          @click="toggleAll"
         >
           <UIcon
             :name="allSelected ? 'i-ph-check-square' : 'i-ph-square'"

--- a/web/app/components/shell/AppToolbar.vue
+++ b/web/app/components/shell/AppToolbar.vue
@@ -142,9 +142,11 @@ const { t } = useI18n()
           v-if="f.kind === 'application'"
           :model-value="f.modelValue.value"
           :options="f.options.value"
+          :none-selected="f.noneSelected?.value"
           :match-mode="f.matchMode?.value"
           :disabled="f.disabled?.value"
           @update:model-value="f.modelValue.value = $event"
+          @update:none-selected="f.noneSelected ? (f.noneSelected.value = $event) : undefined"
           @update:match-mode="f.matchMode ? (f.matchMode.value = $event) : undefined"
         />
         <AppDateTimeRangePicker

--- a/web/app/pages/logs/index.vue
+++ b/web/app/pages/logs/index.vue
@@ -77,6 +77,7 @@ const page = useLogsPage($logsService, {
   initialRange,
   initialPreset: presetQ,
   initialServices,
+  initialNoApplications: strFromQuery('noApplications') === 'true',
   initialSeverity,
   initialBody: strFromQuery('bodyContains'),
   initialAttr: strArrayFromQuery('attr'),
@@ -129,7 +130,7 @@ function describeWindow(range: TimeWindow): string {
 const filters: FilterDescriptor[] = [
   // Application stays interactive in live mode: changing it triggers a reload
   // (watcher inside useLogsPage) and the next live tick uses the new filter.
-  { kind: 'application', modelValue: page.service, options: page.availableServices },
+  { kind: 'application', modelValue: page.service, options: page.availableServices, noneSelected: page.noApplications },
   { kind: 'time-range', modelValue: page.range, preset: page.rangePreset, disabled: page.isLive, retentionDays: $logRetentionDays, maxWindowHours: $queryMaxWindowHours },
   { kind: 'severity', modelValue: page.severityFilter },
   { kind: 'attributes', modelValue: page.attributeFilters },

--- a/web/app/pages/logs/usePage.ts
+++ b/web/app/pages/logs/usePage.ts
@@ -15,6 +15,11 @@ export interface UseLogsPageOptions {
   initialPreset?: string | null
   initialTraceId?: string
   initialServices?: string[]
+  /** When true, the user has explicitly deselected every application
+   *  in the picker — the page short-circuits to an empty list rather
+   *  than the "no filter = all" fallback. Persisted as
+   *  `noApplications=true` in the URL. */
+  initialNoApplications?: boolean
   initialSeverity?: SeverityBucket[]
   initialBody?: string
   initialAttr?: string[]
@@ -69,10 +74,14 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
     : (options.initialRange ?? defaultWindow())
   const range = ref<TimeWindow>(initialWindow)
   const traceId = ref<string | undefined>(options.initialTraceId)
-  // Multi-value allow-list for `service.name`. Empty array is the
-  // canonical "no filter" state — same convention used by the
-  // severity picker and the new `services=` URL param.
+  // Multi-value allow-list for `service.name`. Empty array combined
+  // with `noApplications === false` is the canonical "no filter"
+  // state — same convention used by the severity picker and the
+  // `services=` URL param. `noApplications === true` is the literal
+  // "user deselected every box" state; the fetch is short-circuited
+  // in that branch.
   const serviceFilter = ref<string[]>(options.initialServices ?? [])
+  const noApplications = ref<boolean>(options.initialNoApplications === true)
   const availableServices = ref<string[]>([])
   const limit = ref(options.initialLimit ?? DEFAULT_LIMIT)
   const items = ref<LogRecordDto[]>([])
@@ -98,6 +107,20 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
   }
 
   async function fetchPage(append: boolean) {
+    // "Deselected all" short-circuit: no application selected means no
+    // rows to show — skip the round-trip rather than send a filter the
+    // server would interpret as "no filter".
+    if (noApplications.value) {
+      if (!append) {
+        items.value = []
+        cursor.value = null
+        hasMore.value = false
+        seenKeys.clear()
+      }
+      isLoading.value = false
+      error.value = null
+      return
+    }
     isLoading.value = true
     error.value = null
     try {
@@ -130,6 +153,12 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
   }
 
   async function liveTick() {
+    // Mirror the fetchPage short-circuit: with no applications
+    // selected, the live tail has nothing to fetch.
+    if (noApplications.value) {
+      error.value = null
+      return
+    }
     // Live-tail anchor: newest row we've already shown (items are DESC by
     // time, so items[0] is the newest). Fall back to range.to on empty
     // screen so the first tick doesn't refetch the whole window.
@@ -204,6 +233,7 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
     if (!live.isLive.value) void reload()
   })
   watch(serviceFilter, () => { void reload() }, { deep: true })
+  watch(noApplications, () => { void reload() })
   watch(severityFilter, () => { void reload() }, { deep: true })
   // Body search reloads on each keystroke. The /v1/logs request is
   // light enough that user-perceived latency stays low; if this proves
@@ -230,7 +260,8 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
       q.to = range.value.to
     }
     if (traceId.value) q.traceId = traceId.value
-    if (serviceFilter.value.length > 0) q.services = serviceFilter.value.join(',')
+    if (noApplications.value) q.noApplications = 'true'
+    else if (serviceFilter.value.length > 0) q.services = serviceFilter.value.join(',')
     if (severityFilter.value.length > 0) q.severities = severityFilter.value.join(',')
     const body = bodyQuery.value.trim()
     if (body) q.bodyContains = body
@@ -253,6 +284,7 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
     limit,
     traceId,
     service: serviceFilter,
+    noApplications,
     availableServices,
     items,
     hasMore,

--- a/web/app/pages/traces/index.vue
+++ b/web/app/pages/traces/index.vue
@@ -76,6 +76,7 @@ const page = useTracesPage($traceService, {
   initialRange,
   initialPreset: presetQ,
   initialServices,
+  initialNoApplications: strFromQuery('noApplications') === 'true',
   initialNoService: strFromQuery('noService') === 'true',
   initialServiceMatch: strFromQuery('serviceMatch') === 'any' ? 'any' : 'root',
   initialStatus,
@@ -110,7 +111,7 @@ function describeWindow(range: TimeWindow): string {
 const filters: FilterDescriptor[] = [
   // Application stays interactive in live mode: changing it triggers a reload
   // (watcher inside useTracesPage) and the next live tick uses the new filter.
-  { kind: 'application', modelValue: page.service, options: page.availableServices, matchMode: page.serviceMatch },
+  { kind: 'application', modelValue: page.service, options: page.availableServices, noneSelected: page.noApplications, matchMode: page.serviceMatch },
   { kind: 'time-range', modelValue: page.range, preset: page.rangePreset, disabled: page.isLive, retentionDays: $traceRetentionDays, maxWindowHours: $queryMaxWindowHours },
   { kind: 'status', modelValue: page.statusFilter },
   { kind: 'duration', modelValue: page.durationFilter },

--- a/web/app/pages/traces/usePage.ts
+++ b/web/app/pages/traces/usePage.ts
@@ -18,6 +18,11 @@ export interface UseTracesPageOptions {
    *  ignored in that case. */
   initialPreset?: string | null
   initialServices?: string[]
+  /** When true, the user has explicitly deselected every application
+   *  in the picker — the page short-circuits to an empty list rather
+   *  than the "no filter = all" fallback. Persisted as
+   *  `noApplications=true` in the URL. */
+  initialNoApplications?: boolean
   /** When true, restrict the listing to traces involving Resources
    *  with no `service.name` (null or empty). Drives the service-map's
    *  "(unnamed)" drill-down. Mutually exclusive with `initialService`. */
@@ -65,10 +70,13 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
     ? presetToWindow(rangePreset.value)
     : (options.initialRange ?? defaultWindow())
   const range = ref<TimeWindow>(initialWindow)
-  // Multi-value allow-list for `service.name`. Empty array means
-  // "all applications" — the convention used by the picker and the
-  // server-side `services=` URL param.
+  // Multi-value allow-list for `service.name`. Empty array combined
+  // with `noApplications === false` means "all applications" — the
+  // convention used by the picker and the server-side `services=` URL
+  // param. `noApplications === true` is the literal "user deselected
+  // every box" state; the fetch is short-circuited in that branch.
   const serviceFilter = ref<string[]>(options.initialServices ?? [])
+  const noApplications = ref<boolean>(options.initialNoApplications === true)
   const serviceMatch = ref<'root' | 'any'>(options.initialServiceMatch ?? 'root')
   const noServiceFilter = ref<boolean>(options.initialNoService === true)
   const availableServices = ref<string[]>([])
@@ -88,6 +96,19 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
   const attributeFilters = ref<string[]>(options.initialAttr ?? [])
 
   async function fetchPage(append: boolean) {
+    // "Deselected all" short-circuit: no application selected means no
+    // rows to show — skip the round-trip rather than send a filter the
+    // server would interpret as "no filter".
+    if (noApplications.value) {
+      if (!append) {
+        items.value = []
+        cursor.value = null
+        hasMore.value = false
+      }
+      isLoading.value = false
+      error.value = null
+      return
+    }
     isLoading.value = true
     error.value = null
     try {
@@ -118,6 +139,12 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
   }
 
   async function liveTick() {
+    // Mirror the fetchPage short-circuit: with no applications
+    // selected, the live tail has nothing to fetch.
+    if (noApplications.value) {
+      error.value = null
+      return
+    }
     const anchorIso = items.value[0]?.start ?? range.value.to
     const now = new Date().toISOString()
 
@@ -206,6 +233,7 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
     if (!live.isLive.value) void reload()
   })
   watch(serviceFilter, () => { void reload() }, { deep: true })
+  watch(noApplications, () => { void reload() })
   watch(noServiceFilter, () => { void reload() })
   watch(serviceMatch, () => { void reload() })
   watch(statusFilter, () => { void reload() })
@@ -229,6 +257,7 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
       q.to = range.value.to
     }
     if (noServiceFilter.value) q.noService = 'true'
+    else if (noApplications.value) q.noApplications = 'true'
     else if (serviceFilter.value.length > 0) q.services = serviceFilter.value.join(',')
     if (serviceMatch.value === 'any') q.serviceMatch = 'any'
     if (statusFilter.value !== 'any') q.status = statusFilter.value
@@ -253,6 +282,7 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
     rangePreset,
     limit,
     service: serviceFilter,
+    noApplications,
     noService: noServiceFilter,
     serviceMatch,
     availableServices,

--- a/web/app/types/toolbar.ts
+++ b/web/app/types/toolbar.ts
@@ -20,11 +20,16 @@ export type FilterDescriptor =
 
 export interface ApplicationFilterDescriptor {
   kind: 'application'
-  /** Allow-list of `service.name` values; an empty array means "all
-   *  applications" (no filter). The component renders an "All" pseudo
-   *  option that resets to `[]`. */
+  /** Allow-list of `service.name` values; an empty array combined with
+   *  `noneSelected === false` means "all applications" (no filter).
+   *  The component renders an "All" toggle that flips between
+   *  implicit-all and explicit-none. */
   modelValue: Ref<string[]>
   options: Ref<string[]>
+  /** When true, the user has explicitly deselected every application —
+   *  the page short-circuits to an empty result set. Optional so pages
+   *  that don't want the deselect-all affordance can omit it. */
+  noneSelected?: Ref<boolean>
   /** Optional any-span match toggle. Bound only by pages that want
    *  to expose the discovery alternative ("traces that touch X
    *  anywhere"); when unset the picker hides the toggle and the

--- a/web/i18n/locales/en.json
+++ b/web/i18n/locales/en.json
@@ -61,6 +61,7 @@
     "applicationAll": "All applications",
     "applicationSelect": "Select an application",
     "applicationCount": "{count} applications",
+    "applicationNone": "No applications",
     "applicationEmpty": "No applications in the selected window",
     "applicationMatchModeAny": "Match any span",
     "applicationMatchModeHint": "Include traces that touch the selected services anywhere — not only those rooted on them.",

--- a/web/i18n/locales/it.json
+++ b/web/i18n/locales/it.json
@@ -61,6 +61,7 @@
     "applicationAll": "Tutte le applicazioni",
     "applicationSelect": "Seleziona un'applicazione",
     "applicationCount": "{count} applicazioni",
+    "applicationNone": "Nessuna applicazione",
     "applicationEmpty": "Nessuna applicazione nella finestra selezionata",
     "applicationMatchModeAny": "Match su qualunque span",
     "applicationMatchModeHint": "Includi le tracce che toccano i servizi selezionati ovunque, non solo quelle che vi originano.",


### PR DESCRIPTION
On Traces and Logs the "All applications" box couldn't be unchecked, and there was no quick way to view a single application: clicking "All applications" when already selected was a no-op, and reaching a one-app view required unchecking N-1 boxes by hand.

This makes "All applications" a real toggle (select-all ↔ deselect-all). With it, picking a single app is now two clicks — deselect all, then check the one — and the user can also land on an empty result set the same way checkboxes work everywhere else.