### PR TITLE
fix(traces,logs): show newly-connected services in the Applications filter during Live Mode

### DIFF
--- a/web/app/pages/logs/usePage.ts
+++ b/web/app/pages/logs/usePage.ts
@@ -194,6 +194,10 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
           }
           items.value = items.value.slice(0, MAX_LIVE_ITEMS)
         }
+        // Newly streamed logs may belong to a service that connected
+        // after page load — refresh the picker against the live `now`
+        // window so the Applications filter picks it up.
+        void loadServices(now)
       }
       error.value = null
     } catch (e) {
@@ -201,11 +205,15 @@ export function useLogsPage(service: LogsService, options: UseLogsPageOptions = 
     }
   }
 
-  async function loadServices() {
+  // `toOverride` lets the live tail discover services that connected
+  // after the page loaded: their logs sit past the frozen `range.to`,
+  // so the picker must be refreshed against a live `now` boundary or
+  // they never surface in the Applications filter.
+  async function loadServices(toOverride?: string) {
     try {
       availableServices.value = await service.listServices({
         from: range.value.from,
-        to: range.value.to
+        to: toOverride ?? range.value.to
       })
     } catch {
       // Keep the previous list silent on transient errors so the filter

--- a/web/app/pages/traces/usePage.ts
+++ b/web/app/pages/traces/usePage.ts
@@ -191,6 +191,10 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
         if (items.value.length > MAX_LIVE_ITEMS) {
           items.value = items.value.slice(0, MAX_LIVE_ITEMS)
         }
+        // Newly streamed traces may belong to a service that connected
+        // after page load — refresh the picker against the live `now`
+        // window so the Applications filter picks it up.
+        void loadServices(now)
       } else if (next !== null) {
         items.value = next
       }
@@ -200,11 +204,15 @@ export function useTracesPage(service: TraceService, options: UseTracesPageOptio
     }
   }
 
-  async function loadServices() {
+  // `toOverride` lets the live tail discover services that connected
+  // after the page loaded: their spans sit past the frozen `range.to`,
+  // so the picker must be refreshed against a live `now` boundary or
+  // they never surface in the Applications filter.
+  async function loadServices(toOverride?: string) {
     try {
       availableServices.value = await service.listServices({
         from: range.value.from,
-        to: range.value.to
+        to: toOverride ?? range.value.to
       })
     } catch {
       /* keep previous list silent on transient errors */

--- a/web/tests/pages/useLogsPage.live.spec.ts
+++ b/web/tests/pages/useLogsPage.live.spec.ts
@@ -142,6 +142,49 @@ describe('useLogsPage — live mode', () => {
     page.toggleLive()
   })
 
+  it('refreshes the Applications picker against a live `now` window when a new service streams in', async () => {
+    // A service that connects after page load has logs past the frozen
+    // range.to, so the mount-time /services lookup misses it. The live
+    // tick must re-query /services (with a refreshed `to`) so the new
+    // name lands in the picker options.
+    const initial = makeLog({ time: '2030-01-01T00:00:10.000Z', spanId: 'aaaaaaaaaaaaaaaa' })
+    const liveFresh = makeLog({ time: '2030-01-01T00:00:20.000Z', spanId: 'bbbbbbbbbbbbbbbb' })
+
+    const logsPages: Array<PagedResponse<LogRecordDto>> = [
+      { items: [initial], nextCursor: null },
+      { items: [liveFresh], nextCursor: null }
+    ]
+    let servicesCalls = 0
+    const get = vi.fn(async (path: string) => {
+      if (path === '/v1/logs/services') {
+        servicesCalls += 1
+        // First (mount) lookup: only the original service. Subsequent
+        // lookups: the newly-connected service is now visible.
+        return servicesCalls === 1 ? ['svc-a'] : ['svc-a', 'svc-new']
+      }
+      return logsPages.shift() ?? { items: [], nextCursor: null }
+    })
+    const client = {
+      get,
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn()
+    } as unknown as HttpClientService
+    const service = new LogsService(client)
+
+    const page = useLogsPage(service, { autoLive: false })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(page.availableServices.value).toEqual(['svc-a'])
+
+    page.toggleLive()
+    await vi.advanceTimersByTimeAsync(0) // immediate first live tick
+
+    expect(page.availableServices.value).toEqual(['svc-a', 'svc-new'])
+    expect(get.mock.calls.filter(c => c[0] === '/v1/logs/services').length).toBeGreaterThanOrEqual(2)
+
+    page.toggleLive()
+  })
+
   it('forwards Bearer-less fetch with traceId filter during live ticks', async () => {
     const http = stubHttp([
       { items: [], nextCursor: null },


### PR DESCRIPTION
## Root cause
The picker options come from `loadServices()`, which queries distinct
`service.name` values within the page time window (`range.from → range.to`)
and only runs on init and on range change. In Live Mode `range.to` is frozen
at page-load time, so:
- the service-list query is never re-run while live, and
- even if re-run, its frozen `to` excludes spans/logs newer than `range.to`
  (`WHERE StartUnixNano < toNano`).

## Fix
`loadServices(toOverride?)` accepts an optional upper bound. When a live tick
prepends genuinely new rows, it calls `loadServices(now)` to re-query the
service list against a live `now` window, so the new service lands in the
filter automatically, no page refresh needed.

Applied to both `web/app/pages/traces/usePage.ts` and
`web/app/pages/logs/usePage.ts`.