### PR TITLE
fix(icons): bundle Nuxt UI and .ts catalog icons offline, allow iconify API fallback in CSP

### DIFF
--- a/src/OpenTelemetryDashboard.Host/Hosting/SecurityHeadersExtensions.cs
+++ b/src/OpenTelemetryDashboard.Host/Hosting/SecurityHeadersExtensions.cs
@@ -28,7 +28,8 @@ internal static class SecurityHeadersExtensions
         "style-src 'self' 'unsafe-inline'; " +
         "img-src 'self' data:; " +
         "font-src 'self' data:; " +
-        "connect-src 'self'; " +
+        // api.iconify.design: icons not in the offline bundle load via the API.
+        "connect-src 'self' https://api.iconify.design; " +
         "object-src 'none'; " +
         "base-uri 'self'; " +
         "frame-ancestors 'none'; " +

--- a/tests/OpenTelemetryDashboard.IntegrationTests/SecurityHeadersTests.cs
+++ b/tests/OpenTelemetryDashboard.IntegrationTests/SecurityHeadersTests.cs
@@ -34,6 +34,7 @@ public sealed class SecurityHeadersTests : IClassFixture<TestHostFixture>
         csp.ShouldContain("frame-ancestors 'none'");
         csp.ShouldContain("object-src 'none'");
         csp.ShouldContain("base-uri 'self'");
+        csp.ShouldContain("connect-src 'self' https://api.iconify.design");
     }
 
     [Fact]

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -7,8 +7,23 @@ declare const process: { env: Record<string, string | undefined> }
 // to '/<repo>/' so the bundle resolves under a subpath.
 const APP_BASE_URL = process.env.NUXT_APP_BASE_URL || '/'
 
+// Nuxt UI renders its default icons from node_modules, where `scan` can't see
+// them; without this they'd hit the Iconify API at runtime.
+function bundleNuxtUiIcons(_options: unknown, nuxt: any) {
+  nuxt.hook('icon:clientBundleIcons', (icons: Set<string>) => {
+    const uiIcons = nuxt.options.appConfig?.ui?.icons ?? {}
+    for (const value of Object.values(uiIcons)) {
+      if (typeof value !== 'string') continue
+      const id = value.replace(/^i-/, '')
+      const dash = id.indexOf('-')
+      if (dash === -1) continue
+      icons.add(`${id.slice(0, dash)}:${id.slice(dash + 1)}`)
+    }
+  })
+}
+
 export default defineNuxtConfig({
-  modules: ['@nuxt/ui', '@nuxtjs/i18n'],
+  modules: ['@nuxt/ui', '@nuxtjs/i18n', bundleNuxtUiIcons],
 
   // SPA only. No SSR: `nuxi generate` produces static files served by the
   // ASP.NET host from wwwroot/.
@@ -40,16 +55,14 @@ export default defineNuxtConfig({
     storageKey: 'oteldash-color-mode'
   },
 
-  // Bundle icons into the client JS instead of fetching them at runtime.
-  // Without this Nuxt Icon falls back to api.iconify.design, which our CSP
-  // (connect-src 'self') blocks and which would leak the set of icons we
-  // render to a third party. `scan: true` tree-shakes to just the icons
-  // actually referenced in templates; the @iconify-json/* dev deps provide
-  // the offline source. See the corresponding CSP in
-  // OpenTelemetryDashboard.Host/Hosting/SecurityHeadersExtensions.cs.
   icon: {
+    fallbackToApi: true,
     clientBundle: {
-      scan: true,
+      // .ts: icon names also live as string data in .ts catalogs, which the
+      // default scan globs skip.
+      scan: {
+        globInclude: ['**/*.{vue,jsx,tsx,ts,md,mdc,mdx,yml,yaml}']
+      },
       sizeLimitKb: 512
     }
   },


### PR DESCRIPTION
Icons were resolved at runtime from `api.iconify.design`, which the SPA-shell CSP (`connect-src 'self'`) blocked, leaving select chevrons, spinners, checkboxes and widget icons unrendered.

## Changes

- `web/nuxt.config.ts`
  - Inline module `bundleNuxtUiIcons` adds Nuxt UI's default icons to the client bundle, derived from the merged `appConfig.ui.icons` via the `icon:clientBundleIcons` hook (no hardcoded list; survives @nuxt/ui upgrades). These live in node_modules where `scan` can't see them.
  - `clientBundle.scan.globInclude` extended with `.ts` so icon names stored as string data in catalogs (e.g. the dashboard widget registry) get bundled.
  - `fallbackToApi: true`.
- `SecurityHeadersExtensions.cs`: `connect-src` now allows `https://api.iconify.design` so icons absent from the offline bundle (e.g. those named by external pack data) load via the API fallback. Scoped to `connect-src` only.
- `SecurityHeadersTests.cs`: assert the new `connect-src`.

## Trade-off

Icons not in the bundle are fetched from a third party, exposing those names to iconify. Accepted for externally-supplied pack icons.